### PR TITLE
feat: attempt to add Claude Desktop, but failing

### DIFF
--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -66,6 +66,29 @@
         "type": "github"
       }
     },
+    "claude-desktop": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1735076679,
+        "narHash": "sha256-cg8hkvtb+7RfhHI+2KTYAHU9uxJr83rrANQ1IWpK00M=",
+        "owner": "k3d3",
+        "repo": "claude-desktop-linux-flake",
+        "rev": "722b1c5ffe427dfc1473e4dd371796cffddc2d6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "k3d3",
+        "repo": "claude-desktop-linux-flake",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -140,6 +163,24 @@
         "systems": "systems"
       },
       "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
         "lastModified": 1710146030,
         "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
@@ -153,9 +194,9 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_3": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -171,7 +212,7 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_4": {
       "inputs": {
         "systems": [
           "stylix",
@@ -271,7 +312,7 @@
     "nix-vscode-extensions": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
@@ -307,7 +348,7 @@
     "nixos-wsl": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
@@ -443,6 +484,8 @@
     },
     "root": {
       "inputs": {
+        "claude-desktop": "claude-desktop",
+        "flake-utils": "flake-utils",
         "home-manager": "home-manager",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nixos-hardware": "nixos-hardware",
@@ -460,11 +503,11 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "gnome-shell": "gnome-shell",
         "home-manager": "home-manager_2",
         "nixpkgs": "nixpkgs_5",
-        "systems": "systems_3",
+        "systems": "systems_4",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-tmux": "tinted-tmux"
@@ -515,6 +558,21 @@
       }
     },
     "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -19,6 +19,16 @@
     nur.url = "github:nix-community/NUR";
 
     nix-vscode-extensions.url = "github:nix-community/nix-vscode-extensions";
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    claude-desktop = {
+      url = "github:k3d3/claude-desktop-linux-flake";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
   };
 
   outputs = inputs@{ self, nixpkgs, nixpkgs-unstable, nixos-wsl, nixos-hardware, home-manager, ... }:

--- a/nixos/modules/home/default.nix
+++ b/nixos/modules/home/default.nix
@@ -40,6 +40,8 @@
       # fonts
       nerd-fonts.jetbrains-mono
       jetbrains-mono
+
+      inputs.claude-desktop.packages.${system}.claude-desktop
     ] ++ (if pkgs.stdenv.hostPlatform.system != "aarch64-linux" then [
       # ARM does not support every package, so only install these if we're not on an ARM basd architecture
       bitwarden


### PR DESCRIPTION
We we're following the documentation detailed [here](https://github.com/k3d3/claude-desktop-linux-flake?tab=readme-ov-file#installation-on-nixos-with-flakes).

I'm aware that the documentation details leveraging `NIXPGS_ALLOW_UNFREE`, however I thought that our usage of `allowUnfree` both in `modules/common/default.nix` and `modules/home/defualt.nix` would mean we weouldn't have to do anything else... It seems like our `allowUnfree` is not being plumbed
  correctly...

We're experiencing the following error when attempting to deploy these configuration changes:

```
just deploy foundation
sudo nixos-rebuild switch --flake .#foundation
warning: Git tree '/home/ghilston/Git/toolbox' is dirty
warning: updating lock file '/home/ghilston/Git/toolbox/nixos/flake.lock':
• Added input 'claude-desktop':
    'github:k3d3/claude-desktop-linux-flake/722b1c5ffe427dfc1473e4dd371796cffddc2d6b?narHash=sha256-cg8hkvtb%2B7RfhHI%2B2KTYAHU9uxJr83rrANQ1IWpK00M%3D' (2024-12-24)
• Added input 'claude-desktop/flake-utils':
    follows 'flake-utils'
• Added input 'claude-desktop/nixpkgs':
    follows 'nixpkgs'
• Added input 'flake-utils':
    'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
warning: Git tree '/home/ghilston/Git/toolbox' is dirty
evaluation warning: nur.overlay has been replaced by nur.overlays.default
building the system configuration...
warning: Git tree '/home/ghilston/Git/toolbox' is dirty
evaluation warning: nur.overlay has been replaced by nur.overlays.default
error:
       … while calling the 'head' builtin
         at /nix/store/6zgbbqlr7nnfxpzkyj7fsl4fpg89jbw0-source/lib/attrsets.nix:1574:11:
         1573|         || pred here (elemAt values 1) (head values) then
         1574|           head values
             |           ^
         1575|         else

       … while evaluating the attribute 'value'
         at /nix/store/6zgbbqlr7nnfxpzkyj7fsl4fpg89jbw0-source/lib/modules.nix:846:9:
          845|     in warnDeprecation opt //
          846|       { value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          847|         inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/6zgbbqlr7nnfxpzkyj7fsl4fpg89jbw0-source/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `warnings':

       … while evaluating definitions from `/nix/store/6zgbbqlr7nnfxpzkyj7fsl4fpg89jbw0-source/nixos/modules/system/boot/systemd.nix':

       … while evaluating the option `systemd.services.home-manager-ghilston.serviceConfig':

       … while evaluating definitions from `/nix/store/6zgbbqlr7nnfxpzkyj7fsl4fpg89jbw0-source/flake.nix':

       … while evaluating the option `home-manager.users.ghilston.home.file."/home/ghilston/.config/fontconfig/conf.d/10-hm-fonts.conf".source':

       … while evaluating definitions from `/nix/store/mdzxa36ixdm9g8yli9h73izv3kpj7xjq-source/modules/files.nix':

       … while evaluating the option `home-manager.users.ghilston.home.file."/home/ghilston/.config/fontconfig/conf.d/10-hm-fonts.conf".text':

       … while evaluating definitions from `/nix/store/mdzxa36ixdm9g8yli9h73izv3kpj7xjq-source/modules/misc/xdg.nix':

       … while evaluating the option `home-manager.users.ghilston.xdg.configFile."fontconfig/conf.d/10-hm-fonts.conf".text':

       … while evaluating definitions from `/nix/store/mdzxa36ixdm9g8yli9h73izv3kpj7xjq-source/modules/misc/fontconfig.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Package ‘claude-desktop-0.7.7’ in /nix/store/al4vmxx16ki3dq4yn8dwjxyby73dxnvv-source/pkgs/claude-desktop.nix:128 has an unfree license (‘unfree’), refusing to evaluate.

       a) To temporarily allow unfree packages, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNFREE=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnfree = true; }
       in configuration.nix to override this.

       Alternatively you can configure a predicate to allow specific packages:
         { nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
             "claude-desktop"
           ];
         }

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnfree = true; }
       to ~/.config/nixpkgs/config.nix.
error: Recipe `deploy` failed on line 4 with exit code 1
```