### PR TITLE
feature: treefmt formatter and custom check

### DIFF
--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -478,6 +478,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1747958103,
+        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -536,7 +552,8 @@
         "nixpkgs": "nixpkgs_3",
         "nur": "nur",
         "stylix": "stylix",
-        "systems": "systems_3"
+        "systems": "systems_3",
+        "treefmt-nix": "treefmt-nix_3"
       }
     },
     "stylix": {
@@ -737,6 +754,24 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1750931469,
+        "narHash": "sha256-0IEdQB1nS+uViQw4k3VGUXntjkDp7aAlqcxdewb/hAc=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1",
         "type": "github"
       },
       "original": {

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -15,6 +15,7 @@
     };
     stylix.url = "github:danth/stylix";
     stylix.inputs.nixpkgs.follows = "nixpkgs";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
     nur.url = "github:nix-community/NUR";
     nix-vscode-extensions.url = "github:nix-community/nix-vscode-extensions";
     flake-utils.url = "github:numtide/flake-utils";
@@ -33,6 +34,7 @@
     self,
     nixpkgs,
     systems,
+    treefmt-nix,
     nixos-wsl,
     nixos-hardware,
     home-manager,
@@ -40,7 +42,8 @@
     darwin,
     ...
   }: let
-    lib = nixpkgs.lib // home-manager.lib;
+    # lib = nixpkgs.lib // home-manager.lib;
+    inherit (nixpkgs) lib;
     # Support all major systems (Linux and Darwin)
     allSystems = import systems;
     forEachSystem = f: lib.genAttrs allSystems (system: f pkgsFor.${system});
@@ -51,6 +54,8 @@
           config = {allowUnfree = true;};
         }
     );
+    getTreefmtEval = system: treefmt-nix.lib.evalModule pkgsFor.${system} ./lib/treefmt.nix;
+
     vars = import ./config/vars.nix {inherit (nixpkgs) lib;};
 
     # Helper for home-manager module
@@ -62,7 +67,17 @@
       };
     };
   in {
-    formatter = forEachSystem (pkgs: pkgs.alejandra);
+    # formatter = forEachSystem (pkgs: pkgs.alejandra);
+    # Formatter for nix fmt
+    formatter = forEachSystem (pkgs: (getTreefmtEval pkgs.system).config.build.wrapper);
+
+    # Style check for CI
+    # This creates checks.x86_64-linux.style etc.
+    checks = forEachSystem (pkgs: {
+      style = (getTreefmtEval pkgs.system).config.build.check self;
+      # You can also expose specific custom checks like this:
+      # no-todos = (getTreefmtEval pkgs.system).config.checks.no-todos.check self;
+    });
 
     nixosConfigurations = {
       foundation = nixpkgs.lib.nixosSystem {


### PR DESCRIPTION
- Added treefmt-nix as a flake input:

```nix
treefmt-nix.url = "github:numtide/treefmt-nix";
```

- Simplified our `lib` variable to:

```nix
inherit (nixpkgs) lib;
```

- Within the flakes let expression I defined the `getTreefmtEval` variable that makes our custom configuration available to all systems listed in the systems flake input.

```nix
    getTreefmtEval = system: treefmt-nix.lib.evalModule pkgsFor.${system} ./lib/treefmt.nix;
```

- Finally I added the 2 flake outputs (i.e., after the in keyword):

```nix
    # Formatter for nix fmt
    formatter = forEachSystem (pkgs: (getTreefmtEval pkgs.system).config.build.wrapper);

    # Style check for CI
    # This creates checks.x86_64-linux.style etc.
    checks = forEachSystem (pkgs: {
      style = (getTreefmtEval pkgs.system).config.build.check self;
      # You can also expose specific custom checks like this:
      # no-todos = (getTreefmtEval pkgs.system).config.checks.no-todos.check self;
    });
```

- This provides the `nix fmt` command when in the `nixos` directory it will format your whole configuration recursively.

- Provides a custom `nix flake check` that checks the style of your syntax and will make suggestions on best practices when run. This usually works best when run after `nix fmt`