### PR TITLE
Attempt at fixing mines configuration

### DIFF
--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -22,7 +22,7 @@
     flake-utils.inputs.systems.follows = "systems";
     claude-desktop.url = "github:k3d3/claude-desktop-linux-flake";
     claude-desktop.inputs.nixpkgs.follows = "nixpkgs";
-    claude-desktop.inputs.flake-utils.follows = "flake-utils"; # Corrected: should follow 'flake-utils'
+    claude-desktop.inputs.flake-utils.follows = "flake-utils";
 
     # nix-darwin for macOS support (Keep input if you might use it later, even if no configs defined now)
     darwin.url = "github:LnL7/nix-darwin";

--- a/nixos/hosts/vms/arm/default.nix
+++ b/nixos/hosts/vms/arm/default.nix
@@ -12,23 +12,6 @@
     ../../../modules/common
   ];
 
-  # Add these kernel modules for ARM virtualization
-  boot.initrd.availableKernelModules = [
-    "virtio_pci" # Virtio PCI devices
-    "virtio_blk" # Block storage (disks)
-    "virtio_net" # Network interfaces
-    "virtio_mmio" # Memory-mapped I/O
-    "ext4" # Root filesystem support
-    "nvme" # If using NVMe storage
-  ];
-
-  # Ensure virtio modules are included in initrd
-  boot.initrd.kernelModules = [
-    "virtio_pci"
-    "virtio_blk"
-    "virtio_net"
-  ];
-
   networking.hostName = "nixos-vm";
 
   # Use the systemd-boot EFI boot loader.

--- a/nixos/hosts/vms/mines/default.nix
+++ b/nixos/hosts/vms/mines/default.nix
@@ -7,6 +7,10 @@
     ./hardware-configuration.nix
   ];
 
+  # Use the systemd-boot EFI boot loader.
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
   # Add these kernel modules for ARM virtualization
   boot.initrd.availableKernelModules = [
     "virtio_pci" # Virtio PCI devices
@@ -23,7 +27,7 @@
     "virtio_blk"
     "virtio_net"
   ];
-  # Override the hostname from "nixos-vm" (set in ./arm) to "mines".
+  # Override the hostname from "nixos-vm" to "mines".
   networking.hostName = lib.mkDefault "mines";
 
   # Add any other specific configurations for 'mines' here if it needs

--- a/nixos/hosts/vms/mines/default.nix
+++ b/nixos/hosts/vms/mines/default.nix
@@ -1,12 +1,28 @@
 # nixos/hosts/vms/mines/default.nix
 {lib, ...}: {
-  # Import the generic ARM VM configuration as a base.
-  # This pulls in all settings from nixos/hosts/vms/arm/default.nix,
-  # including its 'hardware-configuration.nix' and other common VM services.
+  # Imports your common/default.nix to share settings
   imports = [
-    ../arm # This refers to nixos/hosts/vms/arm/default.nix
+    ../../../modules/common
+    # run `sudo nixos-generate-config --show-hardware-config > hardware-configuration.nix` to generate
+    ./hardware-configuration.nix
   ];
 
+  # Add these kernel modules for ARM virtualization
+  boot.initrd.availableKernelModules = [
+    "virtio_pci" # Virtio PCI devices
+    "virtio_blk" # Block storage (disks)
+    "virtio_net" # Network interfaces
+    "virtio_mmio" # Memory-mapped I/O
+    "ext4" # Root filesystem support
+    "nvme" # If using NVMe storage
+  ];
+
+  # Ensure virtio modules are included in initrd
+  boot.initrd.kernelModules = [
+    "virtio_pci"
+    "virtio_blk"
+    "virtio_net"
+  ];
   # Override the hostname from "nixos-vm" (set in ./arm) to "mines".
   networking.hostName = lib.mkDefault "mines";
 


### PR DESCRIPTION
Overview

This PR refactors the mines VM configuration to improve reliability and maintainability by:

    Importing only the host-specific hardware-configuration.nix for the mines VM, ensuring that hardware settings (such as disk UUIDs, kernel modules, and device mappings) are always accurate for the target machine.

    Importing the shared `modules/common` module to provide all system, user, desktop, and package settings across hosts, reducing duplication and centralizing configuration management.

Motivation

Previously, the mines configuration imported the `../arm` directory, which also included a `hardware-configuration.nix`that may have been generated on a different machine or VM. This could lead to stage 1 boot failures or other hardware mismatches, especially when deploying to a different architecture or new hardware (such as a Mac with NVMe storage).

By restructuring the imports:

    Each host/VM now uses its own hardware configuration, generated specifically for that environment.

    All common system/user/desktop configuration is shared via modules/common, making it easier to maintain and update global settings.

Implementation

Updated `hosts/vms/mines/default.nix` to:

-  Import ./hardware-configuration.nix (host-specific)

 -  Import ../../../modules/common (shared)

    Removed the direct import of `../arm` to prevent accidental inclusion of an incorrect hardware configuration.

    Added a note in the documentation/comments to clarify this pattern for future hosts/VMs.

Benefits

    Reliability: Prevents stage 1 boot hangs due to mismatched hardware configs.

    Maintainability: Centralizes common configuration, making it easier to manage users, packages, and desktop settings across all hosts.

    Extensibility: Makes it straightforward to add new hosts/VMs—just generate a new `hardware-configuration.nix` and import the shared module.

Next Steps

    For any new VM or host, always generate a fresh `hardware-configuration.nix` on the target system.

    Continue to update modules/common for any settings that should be shared across all systems.
