### PR TITLE
feature: nvidia drivers

### DIFF
--- a/nixos/hosts/pcs/foundation/default.nix
+++ b/nixos/hosts/pcs/foundation/default.nix
@@ -9,6 +9,7 @@
 }: {
   imports = [
     ../../../modules/common
+    ./nvidia_drivers.nix
   ];
 
   networking.hostName = "foundation";
@@ -26,6 +27,9 @@
       initialPassword = "password";
     };
   };
+
+  # Nvidia Drivers Enable/Disable
+  drivers.nvidia.enable = true;
 
   # Override common settings that don't work well in WSL
   services = {

--- a/nixos/hosts/pcs/foundation/nvidia_drivers.nix
+++ b/nixos/hosts/pcs/foundation/nvidia_drivers.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  config,
+  ...
+}:
+with lib; let
+  cfg = config.drivers.nvidia;
+in {
+  options.drivers.nvidia = {
+    enable = mkEnableOption "Enable Nvidia Drivers";
+  };
+
+  config = mkIf cfg.enable {
+    services.xserver.videoDrivers = ["nvidia"];
+    hardware.nvidia = {
+      # Modesetting is required.
+      modesetting.enable = true;
+      # Nvidia power management. Experimental, and can cause sleep/suspend to fail.
+      powerManagement.enable = false;
+      # Fine-grained power management. Turns off GPU when not in use.
+      # Experimental and only works on modern Nvidia GPUs (Turing or newer).
+      powerManagement.finegrained = false;
+      # Use the NVidia open source kernel module (not to be confused with the
+      # independent third-party "nouveau" open source driver).
+      # Support is limited to the Turing and later architectures. Full list of
+      # supported GPUs is at:
+      # https://github.com/NVIDIA/open-gpu-kernel-modules#compatible-gpus
+      # Only available from driver 515.43.04+
+      # Currently alpha-quality/buggy, so false is currently the recommended setting.
+      open = false;
+      # Enable the Nvidia settings menu,
+      # accessible via `nvidia-settings`.
+      nvidiaSettings = true;
+      # Optionally, you may need to select the appropriate driver version for your specific GPU.
+      package = config.boot.kernelPackages.nvidiaPackages.stable;
+    };
+  };
+}


### PR DESCRIPTION
I added nvidia drivers with a custom option to enable/disable for the foundation configuration. In the foundation/default.nix there is an import of the ./nvidia_drivers.nix configuration which has the custom option in it.

To enable or disable the nvidia drivers there is 1 line added to the foundation/default.nix:

drivers.nvidia.enable = true;      # To enable

drivers.nvidia.enable = false;     # To disable and prevent activation

