### PR TITLE
feature: Add steam remote to vm-x86_64

### DIFF
--- a/nixos/hosts/vms/x86_64/default.nix
+++ b/nixos/hosts/vms/x86_64/default.nix
@@ -1,25 +1,34 @@
-{ inputs, outputs, lib, config, pkgs, vars, ... }:
-
 {
+  inputs,
+  outputs,
+  lib,
+  config,
+  pkgs,
+  vars,
+  ...
+}: {
   imports = [
     ./hardware-configuration.nix
     ../../../modules/common
+    ./steam.nix
   ];
 
   networking.hostName = "nixos-vm";
 
   boot.loader.grub = {
     enable = true;
-    device = "/dev/sda";  # Typical for VMs
-    useOSProber = false;  # Usually not needed in VMs
+    device = "/dev/sda"; # Typical for VMs
+    useOSProber = false; # Usually not needed in VMs
   };
+
+  gaming.enable = true;
 
   services.spice-vdagentd.enable = true;
   services.qemuGuest.enable = true;
 
   services.openssh = {
     enable = true;
-    ports = [ 22 ];
+    ports = [22];
     settings = {
       PasswordAuthentication = true;
       AllowUsers = null; # Allows all users by default. Can be [ "user1" "user2" ]

--- a/nixos/hosts/vms/x86_64/steam.nix
+++ b/nixos/hosts/vms/x86_64/steam.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.gaming;
+in {
+  options.gaming = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable gaming module";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [
+      mangohud # Performance monitoring overlay for games
+      lutris # Game manager for Linux
+    ];
+
+    programs.gamescope = {
+      enable = true;
+      capSysNice = true;
+      args =
+        # The --rt (realtime scheduling) argument is generally beneficial for performance
+        # regardless of the display server, so it's always included.
+        ["--rt" "--expose-wayland"];
+      # For x11 use "--x11-specific-arg" instead of "--expose-wayland" above
+    };
+
+    programs.steam = {
+      enable = true;
+      remotePlay.openFirewall = true;
+      dedicatedServer.openFirewall = true;
+      gamescopeSession.enable = true;
+      localNetworkGameTransfers.openFirewall = true;
+    };
+  };
+}


### PR DESCRIPTION
Enable/Disable in `vms/x86_64/default.nix`:

```nix
gaming.enable = true;
gaming.enable = false;
```
- Add `mangohud` for performance monitoring

- Add `lutris` for a game manager

If you prefer something different than `mangohud`
or `lutris` let me know.