### PR TITLE
feature: nh build tool that shows a tree graph of the diffs on rebuild

### DIFF
--- a/nixos/modules/programs/tui/default.nix
+++ b/nixos/modules/programs/tui/default.nix
@@ -1,9 +1,8 @@
-{ ... }:
-
-{
+{...}: {
   imports = [
     ./git
     ./neovim
     ./zsh
+    ./nh.nix
   ];
 }

--- a/nixos/modules/programs/tui/nh.nix
+++ b/nixos/modules/programs/tui/nh.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}: let
+  cfg = config.custom.nh;
+in {
+  options.custom.nh = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable the nh module";
+    };
+    flake = lib.mkOption {
+      type = lib.types.str;
+      default = "${builtins.getEnv "HOME"}/toolbox/nixos";
+      description = "Path to the flake.nix file.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.nh = {
+      enable = true;
+      clean.enable = true;
+      clean.extraArgs = "--keep-since 4d --keep 5";
+      inherit (cfg) flake; # Use the option here
+    };
+    home.packages = with pkgs; [
+      nix-output-monitor
+      nvd
+    ];
+  };
+}


### PR DESCRIPTION
I think nh is a better build tool personally and many agree.

To rebuild use the following command while in the flake directory:

```bash
nh os switch --hostname ghilston .
nh os test --hostname ghilston .
```

You can also use path/to/flake instead of `.`, this is
actually what the `default` value sets in the nh config
so you should be able to omit the path completely and
use `nh os switch`.

I personally have the following shell aliases set for zsh, we can
do the same for you if you like it and want to obv lol

```nix
    shellAliases = {
      sv = "sudo nvim";
      fr = "nh os switch --hostname magic /home/jr/flake";
      ft = "nh os test --hostname magic /home/jr/flake"; # dont save generation to boot menu
      fu = "nh os switch --hostname magic --update /home/jr/flake";
      ncg = "nix-collect-garbage --delete-older-than 3d && sudo nix-collect-garbage -d && sudo /run/current-system/bin/switch-to-configuration boot";
      nc = "nix flake check";
      nt = "nix flake test";
      opts = "man home-configuration.nix";
    }
```
