### PR TITLE
Add: vmware-guest-services to `common/default.nix`

### DIFF
--- a/nixos/hosts/vms/mines/default.nix
+++ b/nixos/hosts/vms/mines/default.nix
@@ -7,26 +7,29 @@
     ./hardware-configuration.nix
   ];
 
+  # VMWare Tools
+  virtualisation.vmware.guest.enable = true;
+
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
   # Add these kernel modules for ARM virtualization
   boot.initrd.availableKernelModules = [
-    "virtio_pci" # Virtio PCI devices
-    "virtio_blk" # Block storage (disks)
-    "virtio_net" # Network interfaces
-    "virtio_mmio" # Memory-mapped I/O
+    # "virtio_pci" # Virtio PCI devices
+    # "virtio_blk" # Block storage (disks)
+    # "virtio_net" # Network interfaces
+    # "virtio_mmio" # Memory-mapped I/O
     "ext4" # Root filesystem support
-    "nvme" # If using NVMe storage
+    # "nvme" # If using NVMe storage
   ];
 
   # Ensure virtio modules are included in initrd
-  boot.initrd.kernelModules = [
-    "virtio_pci"
-    "virtio_blk"
-    "virtio_net"
-  ];
+  # boot.initrd.kernelModules = [
+  #   "virtio_pci"
+  #   "virtio_blk"
+  #   "virtio_net"
+  # ];
   # Override the hostname from "nixos-vm" to "mines".
   networking.hostName = lib.mkDefault "mines";
 


### PR DESCRIPTION
Added the following to your `common/default.nix`:

```nix
  virtualisation = {
    vmware.guest.enable = true;
  };
```

I realize that you only need it for the `mines` configuration but it made sense
to do it like this for your config.

You should consider having a dedicated `home` directory where all things
home-manager go, and a `nixos` directory where all things NixOS go. Currently I
find it hard to differentiate the two since they are so entwined. Just a
thought, it would take some major refactoring but I believe it would make your
configuration easier to follow and easier to maintain.
