### PR TITLE
refactor/vscode extensions

### DIFF
--- a/nixos/justfile
+++ b/nixos/justfile
@@ -43,7 +43,7 @@ upp:
 # Rebuild
 # The host argument is required.
 # The flake_path defaults to the `~/Git/toolbox`
-# Usage: Override the path with `just fr <hostname> flake_path=.` or `just fr <hostname> flake_path=~/toolbox/nixos`
+# Usage: Override the path with `just fr <hostname> .` or `just fr <hostname> ~/toolbox/nixos`
 # Usage: `just fr <hostname>`
 fr host flake_path=flake_path: # Default to current directory
   nh os switch --hostname {{host}} {{flake_path}}
@@ -56,7 +56,8 @@ ft host flake_path=flake_path: # Default to current directory
   nh os test --hostname {{host}} {{flake_path}}
 
 # Update and Rebuild Flake
-# Usage: `just fu <hostname>` flake_path defaults to the cwd
+# Usage: `just fu <hostname>`
+# `just fu <hostname> .` to override the path
 fu host flake_path=flake_path:
     nh os switch --hostname {{host}} --update {{flake_path}}
 

--- a/nixos/modules/programs/gui/vscode/default.nix
+++ b/nixos/modules/programs/gui/vscode/default.nix
@@ -1,4 +1,9 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}: {
   programs.vscode = {
     enable = true;
     package = pkgs.vscode;
@@ -58,6 +63,7 @@
           "<C-n>" = false;
           "<C-b>" = false;
         };
+        # "github.copilot.advanced.completionModel" = "gpt-4";
       };
 
       keybindings = [


### PR DESCRIPTION
feat: Add Copilot GPT-4 model to VSCode user settings

Configures GitHub Copilot to use the GPT-4 completion model within VSCode user
settings in `vscode/default.nix`.

Note: It is currently commented out, replace `"gpt-4"` with your chosen model
and rebuild. If the compiler complains about something something .config/Code,
just delete the whole `Code` directory and rebuild. Since everything should be
managed declaratively, a rebuild should populate the necessary files.
