### PR TITLE
Feat/vscode completion model

### DIFF
--- a/nixos/justfile
+++ b/nixos/justfile
@@ -43,7 +43,7 @@ upp:
 # Rebuild
 # The host argument is required.
 # The flake_path defaults to the `~/Git/toolbox`
-# Usage: Override the path with `just fr <hostname> flake_path=.` or `just fr <hostname> flake_path=~/toolbox/nixos`
+# Usage: Override the path with `just fr <hostname> .` or `just fr <hostname> ~/toolbox/nixos`
 # Usage: `just fr <hostname>`
 fr host flake_path=flake_path: # Default to current directory
   nh os switch --hostname {{host}} {{flake_path}}
@@ -56,7 +56,8 @@ ft host flake_path=flake_path: # Default to current directory
   nh os test --hostname {{host}} {{flake_path}}
 
 # Update and Rebuild Flake
-# Usage: `just fu <hostname>` flake_path defaults to the cwd
+# Usage: `just fu <hostname>`
+# `just fu <hostname> .` to override the path
 fu host flake_path=flake_path:
     nh os switch --hostname {{host}} --update {{flake_path}}
 

--- a/nixos/modules/programs/gui/vscode/default.nix
+++ b/nixos/modules/programs/gui/vscode/default.nix
@@ -1,4 +1,9 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}: {
   programs.vscode = {
     enable = true;
     package = pkgs.vscode;
@@ -58,6 +63,7 @@
           "<C-n>" = false;
           "<C-b>" = false;
         };
+        # "github.copilot.advanced.completionModel" = "gpt-4";
       };
 
       keybindings = [


### PR DESCRIPTION
Add: `completionModel` to `userSettings` in `vscode/default.nix`

Motivation: Declaratively manage and change the copilot completion model

Changes:

Add the following module arguments which are needed for the setting:

```nix
 # vscode/default.nix
{
  pkgs,
  lib,
  config,
  ...
}: {
```
Add the following to `userSettings` in `vscode/default.nix:

```nix
      userSettings = {
        "vim.handleKeys" = {
          "<C-p>" = false;
          "<C-f>" = false;
          "<C-n>" = false;
          "<C-b>" = false;
        };
        # "github.copilot.advanced.completionModel" = "gpt-4";
      };
```

NOTE: Uncomment the above setting and replace `"gpt-4"` with your desired model, and rebuild. If you get errors in relation to `~/.config/Code`, delete the whole `~/.config/Code` directory and then try rebuilding again. It will repopulate the Code directory with our declarative settings.