### PR TITLE
feat: vscode completionModel

### DIFF
--- a/nixos/modules/programs/gui/vscode/default.nix
+++ b/nixos/modules/programs/gui/vscode/default.nix
@@ -1,4 +1,9 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}: {
   programs.vscode = {
     enable = true;
     package = pkgs.vscode;
@@ -58,6 +63,7 @@
           "<C-n>" = false;
           "<C-b>" = false;
         };
+        # "github.copilot.advanced.completionModel" = "gpt-4";
       };
 
       keybindings = [


### PR DESCRIPTION
Add: copilot completionModel setting for changing models declaratively

Add: The following required arguments to `vscode/default.nix`:

```nix
# vscode/default.nix
{
  pkgs,
  config,
  lib,
  ...
}: {
```

Add: The following to `userSettings` in `vscode/default.nix`:

```nix
      userSettings = {
        "vim.handleKeys" = {
          "<C-p>" = false;
          "<C-f>" = false;
          "<C-n>" = false;
          "<C-b>" = false;
        };
        # "github.copilot.advanced.completionModel" = "gpt-4";
      };
```

NOTE: It is currently commented out, choose your desired completion model and rebuild. If you get errors related to `~/.config/Code` delete the `Code` directory and rebuild. It will be repopulated on rebuild.