### PR TITLE
feat: nh build tool  edit flake path

### DIFF
--- a/nixos/modules/programs/tui/nh.nix
+++ b/nixos/modules/programs/tui/nh.nix
@@ -14,7 +14,7 @@ in {
     };
     flake = lib.mkOption {
       type = lib.types.str;
-      default = "${builtins.getEnv "HOME"}/toolbox/nixos";
+      default = "${builtins.getEnv "HOME"}/Git/toolbox/nixos";
       description = "Path to the flake.nix file.";
     };
   };


### PR DESCRIPTION
```nix
  custom = {
    nh = {
      enable = true;
      flake = "${builtins.getEnv "HOME"}/Git/toolbox/nixos";
```

- I take it you don't really use the path `~/toolbox/nixos`, Noted.