### PR TITLE
feat: add binary cache to `flake.nix`

### DIFF
--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -61,6 +61,17 @@
         users.${vars.user.name} = {};
       };
     };
+    caches = {
+      nix.settings = {
+        builders-use-substitutes = true;
+        substituters = [
+          "https://cache.nixos.org"
+        ];
+        trusted-public-keys = [
+          "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+        ];
+      };
+    };
   in {
     formatter = forEachSystem (pkgs: pkgs.alejandra);
 
@@ -77,6 +88,7 @@
           stylix.nixosModules.stylix
           home-manager.nixosModules.home-manager
           mkHomeManagerModule
+          caches
         ];
       };
 
@@ -92,6 +104,7 @@
           stylix.nixosModules.stylix
           home-manager.nixosModules.home-manager
           mkHomeManagerModule
+          caches
         ];
       };
 
@@ -106,6 +119,7 @@
           stylix.nixosModules.stylix
           home-manager.nixosModules.home-manager
           mkHomeManagerModule
+          caches
         ];
       };
 
@@ -120,6 +134,7 @@
           stylix.nixosModules.stylix
           home-manager.nixosModules.home-manager
           mkHomeManagerModule
+          caches
         ];
       };
 
@@ -135,6 +150,7 @@
           stylix.nixosModules.stylix
           home-manager.nixosModules.home-manager
           mkHomeManagerModule
+          caches
         ];
       };
     };


### PR DESCRIPTION
What This Does

`builders-use-substitutes = true`: Ensures that when using remote builders, they can fetch and use prebuilt binaries from the cache.

substituters: Explicitly sets the URL for the main binary cache, guaranteeing Nix looks for prebuilt binaries there first.

trusted-public-keys: Validates binaries from cache.nixos.org for security and authenticity.

How This May Help

Addresses Cache Issues: If your persistent rebuilds are due to Nix not using the official binary cache, this configuration ensures the cache is enabled and trusted.

Reduces Unnecessary Builds: Proper cache settings prevent repeated source builds when otherwise cache hits should occur.

It is unusual for JS to have to build more than once if there weren't any updates or refactors, this should help.
