### PR TITLE
feat: roo-cline official Nixpkgs version

### DIFF
--- a/nixos/modules/programs/gui/vscode/default.nix
+++ b/nixos/modules/programs/gui/vscode/default.nix
@@ -17,6 +17,7 @@
           # tools
           vscodevim.vim
           vspacecode.whichkey
+          rooveterinaryinc.roo-cline
 
           # languages
           golang.go
@@ -42,12 +43,6 @@
             publisher = "GitHub";
             version = "1.270.1373";
             sha256 = "sha256-5HlZKJQBdzXBjWki5owYD9vMo72A/6ukoDNgzIIaJt8=";
-          }
-          {
-            name = "roo-cline";
-            publisher = "RooVeterinaryInc";
-            version = "3.3.19";
-            sha256 = "sha256-4IA9r6yJCn7pJqsCd+WvoEMfjp2K3FvzbTudCjFiqKg=";
           }
         ];
 


### PR DESCRIPTION
Updated version with a new interface. Unfortunately I still don't see the option for different models but it does share the following link when you choose VS Code LM : https://docs.roocode.com/providers/vscode-lm?utm_source=extension&utm_medium=ide&utm_campaign=provider_docs

I still see this warning unfortunately:

```text
You must provide a valid model selector.
Language Model
The VS Code Language Model API allows you to run models provided by other VS Code extensions (including but not limited to GitHub Copilot). The easiest way to get started is to install the Copilot and Copilot Chat extensions from the VS Code Marketplace.
Note: This is a very experimental integration and provider support will vary. If you get an error about a model not being supported, that's an issue on the provider's end.
```

I'll look into using VSCode Nightly or something if possible on NixOS.