### PR TITLE
feat: imperative VSCode

### DIFF
--- a/nixos/modules/home/default.nix
+++ b/nixos/modules/home/default.nix
@@ -2,8 +2,11 @@
   inputs,
   vars,
   pkgs,
+  lib,
   ...
-}: {
+}: let
+  configPath = "/home/ghilston/vscode-config";
+in {
   imports = [
     ../programs/tui
     ../programs/gui
@@ -20,6 +23,17 @@
     inputs.nur.overlays.default
     inputs.nix-vscode-extensions.overlays.default
   ];
+
+  # Symlink settings, keybindings, and extensions
+  home.file.".config/Code/User/settings.json".source =
+    lib.mkForce (lib.file.mkOutOfStoreSymlink "${configPath}/settings.json");
+  # Keybindings
+  home.file.".config/Code/User/keybindings.json".source =
+    lib.mkForce (lib.file.mkOutOfStoreSymlink "${configPath}/keybindings.json");
+
+  # Optionally, manage extensions with a JSON file
+  home.file.".config/Code/User/extensions.json".source =
+    lib.mkForce (lib.file.mkOutOfStoreSymlink "${configPath}/extensions.json");
 
   # User packages. IE not system packages
   home = {

--- a/nixos/modules/programs/gui/default.nix
+++ b/nixos/modules/programs/gui/default.nix
@@ -2,6 +2,6 @@
   imports = [
     ./alacritty
     ./firefox
-    ./vscode
+    # ./vscode
   ];
 }


### PR DESCRIPTION
Add: `mkOutOfStoreSymlink` settings to `home/default.nix`

There is some preparation needed, NixOS will be looking for your config files in `~/vscode-config` in order to use your settings.

1. Prepare Your Writable Directory Create a directory to store these files. For example:

```bash
mkdir -p ~/vscode-config
```

Then download or copy the relevant content from the Gist into appropriate files, for example:

`~/vscode-config/settings.json`

`~/vscode-config/keybindings.json`

`~/vscode-config/extensions.json`

(Others, if needed)

2.  Extensions: Two Approaches

Imperative management: With the Gist's extensions list saved to `~/vscode-config/extensions.json`,
 you can use extensions like `Shan.code-settings-sync` to sync them in-app, or install them manually from that list.

Declarative (optional): If you want to configure extensions using the explicit list provided by the Gist in Nix, you’d need to convert the extension identifiers into the Nix format (see the Home Manager VSCode module documentation).

You (or another user) can edit the files directly in ~/vscode-config/—either by hand, through VSCode, or by updating from the Gist.

Files are not managed by Nix, so settings changes are not overwritten on rebuild.

This setup allows you to combine the reproducibility of Nix with the flexibility of imperative edits and Settings Sync, ensuring both portability and easy, direct management.