### PR TITLE
feat(darwin): add nix-darwin configuration for dungeon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ dot/vim/plugged
 # git submodules
 dot/oh-my-zsh
 dot/vim/bundle/Vundle.vim
+
+# nix build output
+result

--- a/nixos/CLAUDE.md
+++ b/nixos/CLAUDE.md
@@ -5,6 +5,7 @@
 - **isengard** (x86_64 ThinkPad T420)
 - **mines** (aarch64 VM on M4 Mac via VMware Fusion)
 - **home-lab** (x86_64 VM)
+- **dungeon** (aarch64-darwin MacBook Pro 16" M3 Pro — nix-darwin)
 
 ## Common Mistakes to Avoid
 
@@ -12,7 +13,7 @@
 2. **Testing before deploy**: NEVER skip `just ft <host>` before `just fr <host>`
 3. **Hardware configs**: Never edit `hardware-configuration.nix` files - they're auto-generated
 4. **Flake updates**: After updating flake.lock, always test build before deploying
-5. **Architecture mismatch**: Check host architecture (x86_64-linux vs aarch64-linux) matches the config
+5. **Architecture mismatch**: Check host architecture (x86_64-linux vs aarch64-linux vs aarch64-darwin) matches the config
 6. **Home Manager**: User packages go in `modules/home/default.nix`, not system packages
 7. **WSL specifics**: foundation host needs `wsl.enable = true` and related WSL config
 
@@ -22,9 +23,15 @@ ALWAYS test before deploying:
 
 Be sure to select the host, and only the host we're working with. IE if we're developing on the mines host, do not attempt to run `$ just ft home-lab` or `$ just fr home-lab`:
 
+### NixOS hosts
 1. Format: `nix fmt .`
 2. Test build: `just ft <host>`
 3. Deploy: `just fr <host>`
+
+### Darwin hosts (dungeon)
+1. Format: `nix fmt .`
+2. Test build: `just dt <host>`
+3. Deploy: `just dr <host>`
 
 ## Quick Commands
 
@@ -39,6 +46,9 @@ Be sure to select the host, and only the host we're working with. IE if we're de
 - GUI apps: [modules/programs/gui/](modules/programs/gui/)
 - TUI apps: [modules/programs/tui/](modules/programs/tui/)
 - System packages: [modules/common/default.nix](modules/common/default.nix)
+- Darwin system config: [modules/darwin/common.nix](modules/darwin/common.nix)
+- Darwin Homebrew casks: [modules/darwin/homebrew.nix](modules/darwin/homebrew.nix)
+- Darwin home-manager: [modules/darwin/home.nix](modules/darwin/home.nix)
 - Host configs: `hosts/<type>/<hostname>/default.nix`
 
 ## Testing

--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -98,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767028240,
-        "narHash": "sha256-0/fLUqwJ4Z774muguUyn5t8AQ6wyxlNbHexpje+5hRo=",
+        "lastModified": 1773000227,
+        "narHash": "sha256-zm3ftUQw0MPumYi91HovoGhgyZBlM4o3Zy0LhPNwzXE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c31afa6e76da9bbc7c9295e39c7de9fca1071ea1",
+        "rev": "da529ac9e46f25ed5616fd634079a5f3c579135f",
         "type": "github"
       },
       "original": {

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -125,8 +125,18 @@
       };
     };
 
-    # The 'darwinConfigurations' block has been removed entirely because
-    # there are no active macOS configurations.
-    # The 'darwin' input is kept in 'inputs' section in case it's used later.
+    darwinConfigurations = {
+      dungeon = darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+        specialArgs = {
+          inherit inputs vars;
+          outputs = self;
+        };
+        modules = [
+          ./hosts/macs/dungeon
+          home-manager.darwinModules.home-manager
+        ];
+      };
+    };
   };
 }

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -137,6 +137,18 @@
           home-manager.darwinModules.home-manager
         ];
       };
+
+      moria = darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+        specialArgs = {
+          inherit inputs vars;
+          outputs = self;
+        };
+        modules = [
+          ./hosts/macs/moria
+          home-manager.darwinModules.home-manager
+        ];
+      };
     };
   };
 }

--- a/nixos/hosts/macs/dungeon/default.nix
+++ b/nixos/hosts/macs/dungeon/default.nix
@@ -1,0 +1,9 @@
+{...}: {
+  imports = [
+    ../../../modules/darwin/common.nix
+    ../../../modules/darwin/homebrew.nix
+    ../../../modules/darwin/home.nix
+  ];
+
+  networking.hostName = "dungeon";
+}

--- a/nixos/hosts/macs/moria/default.nix
+++ b/nixos/hosts/macs/moria/default.nix
@@ -1,0 +1,9 @@
+{...}: {
+  imports = [
+    ../../../modules/darwin/common.nix
+    ../../../modules/darwin/homebrew.nix
+    ../../../modules/darwin/home.nix
+  ];
+
+  networking.hostName = "moria";
+}

--- a/nixos/justfile
+++ b/nixos/justfile
@@ -74,7 +74,17 @@ gc:
   # garbage collect all unused nix store entries
   sudo nix-collect-garbage --delete-old
 
-# Validate all NixOS configurations (run in devcontainer or any Nix environment)
+# Darwin rebuild (macOS)
+# Usage: `just dr <hostname>`
+dr host flake_path=flake_path:
+  darwin-rebuild switch --flake {{flake_path}}#{{host}}
+
+# Darwin test (macOS)
+# Usage: `just dt <hostname>`
+dt host flake_path=flake_path:
+  darwin-rebuild check --flake {{flake_path}}#{{host}}
+
+# Validate all configurations (run in devcontainer or any Nix environment)
 validate:
   nix flake check
   @echo "Building foundation..."
@@ -85,4 +95,6 @@ validate:
   nix build .#nixosConfigurations.mines.config.system.build.toplevel --dry-run
   @echo "Building home-lab..."
   nix build .#nixosConfigurations.home-lab.config.system.build.toplevel --dry-run
+  @echo "Building dungeon (darwin)..."
+  nix build .#darwinConfigurations.dungeon.system --dry-run
   @echo "All configurations valid!"

--- a/nixos/justfile
+++ b/nixos/justfile
@@ -97,4 +97,6 @@ validate:
   nix build .#nixosConfigurations.home-lab.config.system.build.toplevel --dry-run
   @echo "Building dungeon (darwin)..."
   nix build .#darwinConfigurations.dungeon.system --dry-run
+  @echo "Building moria (darwin)..."
+  nix build .#darwinConfigurations.moria.system --dry-run
   @echo "All configurations valid!"

--- a/nixos/modules/darwin/common.nix
+++ b/nixos/modules/darwin/common.nix
@@ -4,8 +4,8 @@
   pkgs,
   ...
 }: {
-  # Nix settings
-  nix.settings.experimental-features = ["nix-command" "flakes"];
+  # Let Determinate manage the Nix daemon; disable nix-darwin's nix management
+  nix.enable = false;
 
   nixpkgs = {
     overlays = [

--- a/nixos/modules/darwin/common.nix
+++ b/nixos/modules/darwin/common.nix
@@ -75,6 +75,15 @@
       show-recents = false;
       mru-spaces = false;
       minimize-to-application = true;
+      persistent-apps = [
+        "/System/Applications/Finder.app"
+        "/Applications/Firefox.app"
+        "/Applications/Ghostty.app"
+        "/Applications/Slack.app"
+        "/Applications/Obsidian.app"
+        "/Applications/Visual Studio Code.app"
+        "/Applications/Bruno.app"
+      ];
     };
 
     finder = {
@@ -92,6 +101,7 @@
       KeyRepeat = 2;
       NSAutomaticCapitalizationEnabled = false;
       NSAutomaticSpellingCorrectionEnabled = false;
+      "com.apple.swipescrolldirection" = false; # Disable natural scrolling
     };
 
     trackpad = {

--- a/nixos/modules/darwin/common.nix
+++ b/nixos/modules/darwin/common.nix
@@ -1,0 +1,112 @@
+{
+  inputs,
+  vars,
+  pkgs,
+  ...
+}: {
+  # Nix settings
+  nix.settings.experimental-features = ["nix-command" "flakes"];
+
+  nixpkgs = {
+    overlays = [
+      inputs.nur.overlays.default
+      inputs.nix-vscode-extensions.overlays.default
+    ];
+    config = {
+      allowUnfree = true;
+    };
+  };
+
+  # Primary user (required for system.defaults, homebrew, etc.)
+  system.primaryUser = vars.user.name;
+
+  # User setup
+  users.users.${vars.user.name} = {
+    home = "/Users/${vars.user.name}";
+    shell = pkgs.${vars.user.packages.shell};
+  };
+
+  # System packages (CLI tools available system-wide)
+  environment = {
+    systemPackages = with pkgs; [
+      bat
+      zsh
+      tmux
+      file
+      git
+      htop
+      jq
+      rsync
+      tldr
+      neovim
+      vimPlugins.vim-plug
+      unzip
+      wget
+      curl
+      zip
+      tree
+      ncdu
+      just
+      gcc
+      lazygit
+      ripgrep
+      fd
+      python3
+      pandoc
+      gnumake
+      docker-compose
+
+      # Modern CLI tools
+      btop
+      bruno-cli
+      gh
+      yq-go
+    ];
+
+    variables = {
+      EDITOR = "nvim";
+    };
+  };
+
+  # macOS system preferences (declarative)
+  system.defaults = {
+    dock = {
+      autohide = true;
+      show-recents = false;
+      mru-spaces = false;
+      minimize-to-application = true;
+    };
+
+    finder = {
+      AppleShowAllExtensions = true;
+      FXPreferredViewStyle = "Nlsv"; # List view
+      ShowPathbar = true;
+      ShowStatusBar = true;
+      _FXShowPosixPathInTitle = true;
+    };
+
+    NSGlobalDomain = {
+      AppleShowAllExtensions = true;
+      AppleInterfaceStyle = "Dark";
+      InitialKeyRepeat = 15;
+      KeyRepeat = 2;
+      NSAutomaticCapitalizationEnabled = false;
+      NSAutomaticSpellingCorrectionEnabled = false;
+    };
+
+    trackpad = {
+      Clicking = true;
+      TrackpadRightClick = true;
+      TrackpadThreeFingerDrag = true;
+    };
+  };
+
+  # Touch ID for sudo
+  security.pam.services.sudo_local.touchIdAuth = true;
+
+  # Timezone
+  time.timeZone = vars.system.timeZone;
+
+  # nix-darwin state version
+  system.stateVersion = 6;
+}

--- a/nixos/modules/darwin/home.nix
+++ b/nixos/modules/darwin/home.nix
@@ -1,0 +1,61 @@
+{
+  inputs,
+  vars,
+  pkgs,
+  ...
+}: {
+  home-manager = {
+    useUserPackages = true;
+    backupFileExtension = "backup";
+    extraSpecialArgs = {
+      inherit inputs vars;
+    };
+    users.${vars.user.name} = {
+      imports = [
+        ../../modules/programs/tui
+      ];
+
+      nixpkgs = {
+        config = {
+          allowUnfree = true;
+          allowUnfreePredicate = _: true;
+        };
+        overlays = [
+          inputs.nur.overlays.default
+          inputs.nix-vscode-extensions.overlays.default
+        ];
+      };
+
+      home = {
+        username = vars.user.name;
+        homeDirectory = "/Users/${vars.user.name}";
+        packages = with pkgs; [
+          # TUI/CLI tools
+          ncdu
+          ollama
+          ripgrep
+          hugo
+          go
+          duckdb
+          claude-code
+
+          # Fonts
+          nerd-fonts.jetbrains-mono
+          jetbrains-mono
+        ];
+      };
+
+      custom = {
+        nh = {
+          enable = true;
+          flake = vars.paths.nixosFlake;
+        };
+        yazi.enable = true;
+      };
+
+      programs.home-manager.enable = true;
+
+      home.stateVersion = "24.05";
+    };
+  };
+}

--- a/nixos/modules/darwin/homebrew.nix
+++ b/nixos/modules/darwin/homebrew.nix
@@ -8,6 +8,10 @@
       upgrade = true;
     };
 
+    taps = [
+      "nikitabobko/tap" # AeroSpace
+    ];
+
     casks = [
       # Core
       "1password"

--- a/nixos/modules/darwin/homebrew.nix
+++ b/nixos/modules/darwin/homebrew.nix
@@ -8,14 +8,13 @@
       upgrade = true;
     };
 
-    taps = [
-      "nikitabobko/tap" # AeroSpace
-    ];
+    # TODO: add back aerospace once brew bundle tap issue is resolved
+    # taps = [
+    #   "nikitabobko/tap" # AeroSpace
+    # ];
 
     casks = [
       # Core
-      "1password"
-      "alacritty"
       "ghostty"
       "firefox"
       "google-chrome"
@@ -24,7 +23,6 @@
       # Communication
       "discord"
       "slack"
-      "microsoft-onenote"
 
       # Media
       "spotify"
@@ -36,7 +34,6 @@
       "docker"
       "dbeaver-community"
       "db-browser-for-sqlite"
-      "postman"
       "ngrok"
 
       # Productivity
@@ -44,7 +41,7 @@
       "raycast"
       "stats"
       "bartender"
-      "aerospace"
+      # "aerospace" # Requires nikitabobko/tap - install manually for now
 
       # AI
       "claude"
@@ -53,7 +50,6 @@
 
       # Other
       "bitwarden"
-      "anki"
       "flux"
       "steam"
       "godot"

--- a/nixos/modules/darwin/homebrew.nix
+++ b/nixos/modules/darwin/homebrew.nix
@@ -4,14 +4,13 @@
 
     onActivation = {
       autoUpdate = true;
-      cleanup = "zap";
+      cleanup = "check";
       upgrade = true;
     };
 
-    # TODO: add back aerospace once brew bundle tap issue is resolved
-    # taps = [
-    #   "nikitabobko/tap" # AeroSpace
-    # ];
+    taps = [
+      "nikitabobko/tap" # AeroSpace
+    ];
 
     casks = [
       # Core
@@ -41,7 +40,7 @@
       "raycast"
       "stats"
       "bartender"
-      # "aerospace" # Requires nikitabobko/tap - install manually for now
+      "aerospace"
 
       # AI
       "claude"

--- a/nixos/modules/darwin/homebrew.nix
+++ b/nixos/modules/darwin/homebrew.nix
@@ -1,0 +1,58 @@
+{...}: {
+  homebrew = {
+    enable = true;
+
+    onActivation = {
+      autoUpdate = true;
+      cleanup = "zap";
+      upgrade = true;
+    };
+
+    casks = [
+      # Core
+      "1password"
+      "alacritty"
+      "ghostty"
+      "firefox"
+      "google-chrome"
+      "visual-studio-code"
+
+      # Communication
+      "discord"
+      "slack"
+      "microsoft-onenote"
+
+      # Media
+      "spotify"
+      "vlc"
+      "calibre"
+
+      # Dev
+      "bruno"
+      "docker"
+      "dbeaver-community"
+      "db-browser-for-sqlite"
+      "postman"
+      "ngrok"
+
+      # Productivity
+      "obsidian"
+      "raycast"
+      "stats"
+      "bartender"
+      "aerospace"
+
+      # AI
+      "claude"
+      "lm-studio"
+      "draw-things"
+
+      # Other
+      "bitwarden"
+      "anki"
+      "flux"
+      "steam"
+      "godot"
+    ];
+  };
+}

--- a/nixos/modules/programs/tui/zsh/default.nix
+++ b/nixos/modules/programs/tui/zsh/default.nix
@@ -1,6 +1,7 @@
 {
   vars,
   pkgs,
+  config,
   ...
 }: {
   programs.zsh = {
@@ -60,9 +61,15 @@
       gitCommitUndo = "git reset --soft HEAD\\^";
       cat = "bat";
       # Clipboard: uses xclip if available (GUI systems), otherwise suggests alternatives
-      clip = "if command -v xclip &> /dev/null; then xclip -sel clip <; else echo 'xclip not available. On WSL use clip.exe, on Wayland use wl-copy'; fi";
+      clip =
+        if pkgs.stdenv.isDarwin
+        then "pbcopy <"
+        else "if command -v xclip &> /dev/null; then xclip -sel clip <; else echo 'xclip not available. On WSL use clip.exe, on Wayland use wl-copy'; fi";
       # nix garbage collect
-      ncg = "nix-collect-garbage --delete-older-than 3d && sudo nix-collect-garbage -d && sudo /run/current-system/bin/switch-to-configuration boot";
+      ncg =
+        if pkgs.stdenv.isDarwin
+        then "nix-collect-garbage --delete-older-than 3d && sudo nix-collect-garbage -d"
+        else "nix-collect-garbage --delete-older-than 3d && sudo nix-collect-garbage -d && sudo /run/current-system/bin/switch-to-configuration boot";
       nc = "nix flake check";
       nt = "nix flake test";
       opts = "man home-configuration.nix";
@@ -89,6 +96,6 @@
       cd = "echo '💡 Tip: Use \"z\" for smart directory jumping! (or use \"builtin cd\" for traditional cd)' && builtin cd";
     };
     history.size = 10000;
-    history.path = "/home/${vars.user.name}/.zsh_history";
+    history.path = "${config.home.homeDirectory}/.zsh_history";
   };
 }


### PR DESCRIPTION
To deploy on dungeon:

1. Install Nix: `$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install`
2. Install Homebrew: `$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
3. Clone repo: `$ mkdir -p ~/Git && git clone https://github.com/GregHilston/
toolbox.git ~/Git/toolbox`
4. Checkout this branch `$ cd ~/Git/toolbox && git fetch --all && git checkout feat-nix-darwin-for-dungeon`
5. Close the terminal and open a new one
6. First build: `$ nix build ~/Git/toolbox/nixos#darwinConfigurations.dungeon.system && sudo ./result/activate`
7. After that: `$ just dr dungeon`