### PR TITLE
Add ser2net launchd agent for USB serial over TCP

### DIFF
--- a/dot/ser2net/.config/ser2net/ser2net.yaml
+++ b/dot/ser2net/.config/ser2net/ser2net.yaml
@@ -1,0 +1,25 @@
+# ser2net configuration for exposing USB serial devices over TCP.
+# OrbStack has no USB passthrough, so Docker containers connect to these
+# TCP ports instead of accessing USB devices directly.
+#
+# To find your device paths after plugging in USB sticks:
+#   ls /dev/cu.usb*
+#
+# Replace the placeholder paths below with the actual device paths.
+# Common examples:
+#   /dev/cu.usbmodem14101    (Silicon Labs / Zigbee)
+#   /dev/cu.usbserial-0001   (FTDI / Z-Wave)
+#
+# Containers connect via host.orb.internal:<port> (OrbStack's host alias).
+
+connection: &zigbee
+  accepter: tcp,0.0.0.0,20108
+  connector: serialdev,/dev/cu.ZIGBEE_DEVICE,115200n81,local
+  options:
+    kickolduser: true
+
+connection: &zwave
+  accepter: tcp,0.0.0.0,20109
+  connector: serialdev,/dev/cu.ZWAVE_DEVICE,115200n81,local
+  options:
+    kickolduser: true

--- a/nixos/hosts/macs/dungeon/default.nix
+++ b/nixos/hosts/macs/dungeon/default.nix
@@ -9,6 +9,7 @@
     ../../../modules/darwin/homebrew.nix
     ../../../modules/darwin/home.nix
     ../../../modules/darwin/omlx.nix
+    ../../../modules/darwin/ser2net.nix
   ];
 
   networking.hostName = "dungeon";
@@ -202,6 +203,7 @@
     # into the repo. Without it, oMLX writes land directly in the git tree.
     cd "$TOOLBOX"
     stow -R --no-folding omlx
+    stow -R --no-folding ser2net
 
     # Merge base settings.json + dungeon cache overlay → ~/.omlx/settings.json
     # Write to a temp file first, then mv into place. This avoids truncating the

--- a/nixos/modules/darwin/homebrew.nix
+++ b/nixos/modules/darwin/homebrew.nix
@@ -32,6 +32,7 @@
 
     brews = [
       "stow"
+      "ser2net" # Exposes USB serial devices over TCP for OrbStack containers
 
       # CLI tools — managed here rather than nix for easier updates on macOS
       "tmux"

--- a/nixos/modules/darwin/ser2net.nix
+++ b/nixos/modules/darwin/ser2net.nix
@@ -1,0 +1,20 @@
+{vars, ...}: {
+  # Expose USB serial devices (Zigbee/Z-Wave sticks) over TCP via ser2net.
+  # OrbStack has no USB passthrough, so Docker containers connect to these
+  # TCP sockets instead. See ~/Git/home-lab/docs/usb-passthrough-orbstack.md.
+  #
+  # Ports:
+  #   20108 — Zigbee coordinator (zigbee2mqtt connects here)
+  #   20109 — Z-Wave controller (Z-Wave JS UI connects here)
+  #
+  # Config: ~/.config/ser2net/ser2net.yaml (deployed via stow)
+  launchd.user.agents.ser2net = {
+    command = "/opt/homebrew/opt/ser2net/sbin/ser2net -n -c /Users/${vars.user.name}/.config/ser2net/ser2net.yaml";
+    serviceConfig = {
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/ser2net.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/ser2net.log";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `ser2net` to Homebrew brews for exposing USB serial devices over TCP
- New `ser2net.nix` module: launchd user agent (follows the oMLX pattern)
- Stow-managed config at `~/.config/ser2net/ser2net.yaml` with placeholder device paths
- Imported on dungeon with stow deployment in postActivation

OrbStack has no USB passthrough ([orbstack/orbstack#43](https://github.com/orbstack/orbstack/issues/43)). This exposes Zigbee (TCP 20108) and Z-Wave (TCP 20109) USB sticks so Docker containers can connect via `tcp://host.orb.internal:<port>`.

Supersedes #56 (native zigbee2mqtt/zwavejs approach). Companion PR: [home-lab#18](https://github.com/GregHilston/home-lab/pull/18).

## Test plan

- [ ] `darwin-rebuild switch` succeeds
- [ ] `launchctl list | grep ser2net` shows the service
- [ ] Plug in USB sticks, update device paths in `~/.config/ser2net/ser2net.yaml`
- [ ] `nc -z localhost 20108` and `nc -z localhost 20109` confirm TCP ports are open