### PR TITLE
feat(dungeon): launchd agent for NFS stale-handle self-heal

### DIFF
--- a/nixos/hosts/macs/dungeon/default.nix
+++ b/nixos/hosts/macs/dungeon/default.nix
@@ -187,6 +187,22 @@
     };
   };
 
+  # Detect & auto-heal stale NFS file handles (ESTALE) on the home-lab_nfs-* Docker volumes.
+  # Runs as a USER agent (not a system daemon) so it inherits the GUI/OrbStack docker context.
+  # Root cause + manual fix: home-lab/CLAUDE.md → "NFS Stale File Handle (ESTALE)".
+  launchd.user.agents.nfs-stale-check = {
+    serviceConfig = {
+      ProgramArguments = [
+        "/bin/bash"
+        "/Users/${vars.user.name}/Git/home-lab/scripts/nfs-stale-check.sh"
+      ];
+      RunAtLoad = true;
+      StartInterval = 300; # every 5 min — probe is cheap (a few `docker exec ls`)
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/nfs-stale-check.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/nfs-stale-check.log";
+    };
+  };
+
   # Deploy oMLX with dungeon-specific settings (8GB hot cache for M3 Pro 36GB)
   # See ~/Git/toolbox/dot/omlx/README.md for stow strategy explanation
   # Combined with home-lab-config deployment and power management


### PR DESCRIPTION
Schedules `home-lab/scripts/nfs-stale-check.sh` every 5 min on dungeon as a launchd **user** agent (so it inherits the GUI/OrbStack docker context — a system daemon can't reach the user's Docker).

Pairs with home-lab PR #23 (already merged): the script auto-detects & heals stale NFS handles on the `home-lab_nfs-*` volumes, and alerts via Pushover on outage/recovery.

**After merge:** `darwin-rebuild switch` on dungeon to install the agent. Then verify with `launchctl kickstart -k gui/$(id -u)/nfs-stale-check` and check `~/Library/Logs/nfs-stale-check.log`.

Only touches `nixos/hosts/macs/dungeon/default.nix` (one hunk).