### PR TITLE
feat(darwin): run Frigate ANE object detector as a launchd agent on dungeon

### DIFF
--- a/nixos/docs/darwin-post-deploy.md
+++ b/nixos/docs/darwin-post-deploy.md
@@ -24,6 +24,15 @@ Run these tasks after initial deployment on a new Mac.
 - [ ] Clone notes repo: `git clone git@github.com:<user>/notes.git ~/Notes`
 - [ ] Clone other personal repos as needed
 
+## Frigate ANE Detector (dungeon only)
+The `frigate-detector` launchd agent (hosts/macs/dungeon/default.nix) runs the native
+Apple-Silicon object detector that Frigate connects to over ZMQ. It is not auto-cloned:
+- [ ] `git clone https://github.com/frigate-nvr/apple-silicon-detector ~/Git/apple-silicon-detector`
+- [ ] `cd ~/Git/apple-silicon-detector && /opt/homebrew/bin/python3.11 -m venv venv`
+- [ ] `./venv/bin/pip3 install -r requirements.txt`
+- [ ] Re-run `darwin-rebuild switch` so the agent finds the venv, then verify:
+      `tail ~/Library/Logs/frigate-detector.log` shows "ZMQ server successfully bound to tcp://*:5555"
+
 ## Launch Applications
 
 - [ ] Set up AeroSpace tiling

--- a/nixos/hosts/macs/dungeon/default.nix
+++ b/nixos/hosts/macs/dungeon/default.nix
@@ -346,4 +346,31 @@
       StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/mac-battery-textfile.log";
     };
   };
+
+  # ---------------------------------------------------------------------------
+  # Frigate object detection on the Apple Neural Engine.
+  # Frigate runs in OrbStack's Linux VM, which can't reach the ANE — so the
+  # detector (frigate-nvr/apple-silicon-detector) runs NATIVELY here and Frigate
+  # connects from the container over ZMQ/TCP (config: detectors.type=zmq,
+  # endpoint=tcp://host.docker.internal:5555). This moves the single biggest
+  # CPU consumer (CPU inference was ~64% of Frigate's load) onto the Neural
+  # Engine. Run in AUTO mode: Frigate ships the yolov9 model over ZMQ on connect.
+  # Manual one-time install (not auto-cloned — see darwin-post-deploy.md):
+  #   git clone https://github.com/frigate-nvr/apple-silicon-detector ~/Git/apple-silicon-detector
+  #   cd ~/Git/apple-silicon-detector && /opt/homebrew/bin/python3.11 -m venv venv
+  #   ./venv/bin/pip3 install -r requirements.txt
+  launchd.user.agents.frigate-detector = {
+    serviceConfig = {
+      ProgramArguments = [
+        "/Users/${vars.user.name}/Git/apple-silicon-detector/venv/bin/python3"
+        "-u"
+        "/Users/${vars.user.name}/Git/apple-silicon-detector/detector/zmq_onnx_client.py"
+      ];
+      WorkingDirectory = "/Users/${vars.user.name}/Git/apple-silicon-detector";
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/frigate-detector.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/frigate-detector.log";
+    };
+  };
 }


### PR DESCRIPTION
## Why

Frigate's CPU object detector was the single biggest CPU consumer on dungeon (~64% of a ~130% total).
Frigate runs inside OrbStack's Linux VM, which can't reach the Apple Neural Engine, so the detector
has to run **natively** on the Mac and Frigate connects to it over ZMQ/TCP. (Companion change in the
home-lab repo points Frigate at it.)

## What

- Add `launchd.user.agents.frigate-detector` to `nixos/hosts/macs/dungeon/default.nix`, running the
  native [`frigate-nvr/apple-silicon-detector`](https://github.com/frigate-nvr/apple-silicon-detector)
  (`venv/bin/python3 detector/zmq_onnx_client.py`, defaults to `tcp://*:5555`, `--model AUTO`). Mirrors
  the existing native-exporter agent pattern (node_exporter / macmon / glances): `RunAtLoad`,
  `KeepAlive`, logs to `~/Library/Logs/frigate-detector.log`.
- Document the one-time clone + venv install in `nixos/docs/darwin-post-deploy.md` (the detector repo
  is not auto-cloned).

## Deploy

The detector repo + venv must exist first (see the post-deploy checklist), then
`darwin-rebuild switch` starts the agent. Verify with
`tail ~/Library/Logs/frigate-detector.log` → "ZMQ server successfully bound to tcp://*:5555".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
