### PR TITLE
docs(nixos): add runnable direnv + flake dev-shell examples

### DIFF
--- a/nixos/CLAUDE.md
+++ b/nixos/CLAUDE.md
@@ -112,6 +112,7 @@ For extended-context or other model profiles, see `dot/omlx/CLAUDE.md` → "Crea
 - SSH client config: [modules/programs/tui/ssh.nix](modules/programs/tui/ssh.nix)
 - Host configs: `hosts/<type>/<hostname>/default.nix`
 - LLM settings: `~/Git/toolbox/dot/omlx/.omlx/settings.json` (reproducible oMLX config)
+- Example per-project dev shells (direnv + flake): [examples/](examples/) (`python-devshell/`, `typescript-devshell/`)
 
 ## Testing
 

--- a/nixos/README.md
+++ b/nixos/README.md
@@ -169,6 +169,11 @@ When you enter a project directory with a `flake.nix` and `.envrc`, direnv autom
 
 ### Setup a New Project
 
+> **Prefer to copy a working example?** See [`examples/`](examples/) for complete,
+> runnable versions of the snippets below — [`python-devshell/`](examples/python-devshell/)
+> and [`typescript-devshell/`](examples/typescript-devshell/). Each is a directory you can
+> copy, `direnv allow`, and run immediately.
+
 #### Python Project
 ```bash
 # Create project

--- a/nixos/examples/.gitignore
+++ b/nixos/examples/.gitignore
@@ -1,0 +1,10 @@
+# direnv's cached shell — machine-local, regenerated on demand
+.direnv/
+
+# python
+__pycache__/
+*.pyc
+
+# typescript / node
+node_modules/
+hello.js

--- a/nixos/examples/README.md
+++ b/nixos/examples/README.md
@@ -1,0 +1,72 @@
+# Per-Project Dev Environment Examples
+
+Runnable, copy-me examples of this repo's per-project development workflow:
+**`direnv` + `nix-direnv` + a Nix flake `devShell`**. No Docker — the flake *is*
+the environment. `cd` into a project and its tools load automatically; leave and
+they unload.
+
+This is the runnable companion to the
+[Per-Project Development Environments](../README.md#per-project-development-environments)
+section of `nixos/README.md`.
+
+## Examples
+
+| Directory | Provides |
+|-----------|----------|
+| [`python-devshell/`](python-devshell/) | Python 3 + `requests` + `ruff` |
+| [`typescript-devshell/`](typescript-devshell/) | Node.js 22 + `typescript` (`tsc`) |
+
+Each example is just three files: `flake.nix` (the environment), `.envrc`
+(`use flake` — the direnv hook that auto-loads it), and a tiny `hello` program
+that proves the toolchain is on `PATH`.
+
+## How it works
+
+1. `flake.nix` declares a `devShells.default` listing the exact tools/packages.
+   It uses [`flake-utils`](https://github.com/numtide/flake-utils)'
+   `eachDefaultSystem`, so the same flake works on every architecture
+   (x86_64-linux, aarch64-linux, aarch64-darwin, …) with no edits.
+2. `.envrc` contains a single line, `use flake`. When you enter the directory,
+   direnv evaluates the flake and exports the dev shell into your shell —
+   including editors/LSPs launched from it.
+3. `nix-direnv` **caches** the built shell (and pins it as a GC root), so
+   re-entry is near-instant and garbage collection won't blow the toolchain away.
+
+Because the direnv + nix-direnv module (`modules/programs/tui/direnv/`) is already
+enabled on every Nix-managed host, direnv and the caching are there out of the box.
+
+## Try it
+
+### Python
+
+```bash
+cd python-devshell
+direnv allow      # one-time: trust this .envrc. From now on the env auto-loads on cd.
+python hello.py   # runs the flake's Python, with requests available
+
+# Without direnv:
+nix develop       # drops you into the same shell manually
+python hello.py
+```
+
+### TypeScript
+
+```bash
+cd typescript-devshell
+direnv allow
+tsc hello.ts && node hello.js   # both tsc and node come from the flake
+
+# Without direnv:
+nix develop
+tsc hello.ts && node hello.js
+```
+
+Leaving the directory (`cd ..`) unloads the environment automatically.
+
+## A note on `flake.lock`
+
+These examples ship **without** a committed `flake.lock`. The first
+`direnv allow` / `nix develop` generates one, pinning `nixpkgs` to an exact
+revision. For a real project you'd **commit `flake.lock`** so every contributor
+gets a byte-for-byte identical toolchain — that lock file is what makes the
+environment truly reproducible.

--- a/nixos/examples/python-devshell/.envrc
+++ b/nixos/examples/python-devshell/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/nixos/examples/python-devshell/flake.nix
+++ b/nixos/examples/python-devshell/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Example Python dev environment (direnv + Nix flake)";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+      python = pkgs.python3.withPackages (ps: with ps; [requests]);
+    in {
+      devShells.default = pkgs.mkShell {
+        packages = [python pkgs.ruff];
+        shellHook = ''echo "python dev shell · $(python --version)"'';
+      };
+    });
+}

--- a/nixos/examples/python-devshell/hello.py
+++ b/nixos/examples/python-devshell/hello.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Tiny script proving the flake's Python + packages are on PATH.
+
+`requests` is imported (not called) so this runs offline — if the import
+succeeds, the dev shell loaded the flake's Python environment correctly.
+"""
+
+import sys
+
+import requests  # provided by the flake, not the system Python
+
+
+def main() -> None:
+    print(f"Hello from Python {sys.version.split()[0]}")
+    print(f"requests {requests.__version__} is importable — the dev shell works.")
+
+
+if __name__ == "__main__":
+    main()

--- a/nixos/examples/typescript-devshell/.envrc
+++ b/nixos/examples/typescript-devshell/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/nixos/examples/typescript-devshell/flake.nix
+++ b/nixos/examples/typescript-devshell/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Example TypeScript dev environment (direnv + Nix flake)";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+    in {
+      devShells.default = pkgs.mkShell {
+        packages = with pkgs; [nodejs_22 typescript];
+        shellHook = ''echo "typescript dev shell · node $(node --version)"'';
+      };
+    });
+}

--- a/nixos/examples/typescript-devshell/hello.ts
+++ b/nixos/examples/typescript-devshell/hello.ts
@@ -1,0 +1,9 @@
+// Tiny typed program proving the flake's Node + TypeScript are on PATH.
+// Compile and run:  tsc hello.ts && node hello.js
+// Both `tsc` and `node` come from the flake's dev shell.
+
+function greet(name: string): string {
+  return `Hello, ${name}! The TypeScript dev shell works.`;
+}
+
+console.log(greet("world"));


### PR DESCRIPTION
## What & why

`nixos/README.md` already teaches our per-project dev-environment workflow — `direnv` + `nix-direnv` + a flake `devShell`, **no Docker** — but only as inline `cat > flake.nix <<EOF` heredocs pinned to `aarch64-linux`. Nothing you can actually `cd` into and run.

This adds two **copy-and-run example projects** under a new `nixos/examples/` so the workflow is demonstrated by a real directory, not a snippet.

## Changes

New `nixos/examples/`:

| File | Purpose |
|------|---------|
| `README.md` | Brief explainer: how direnv + flakes work, and the exact commands to run |
| `.gitignore` | Ignores `.direnv/`, `__pycache__/`, `*.pyc`, `node_modules/`, compiled `hello.js` |
| `python-devshell/` | `flake.nix` (Python 3 + `requests` + `ruff`), `.envrc` (`use flake`), `hello.py` |
| `typescript-devshell/` | `flake.nix` (Node.js 22 + `typescript`), `.envrc` (`use flake`), `hello.ts` |

Both flakes use `flake-utils.eachDefaultSystem`, so they work on **every** host architecture with no edits — unlike the arch-pinned heredocs they complement.

Doc links (as requested):
- **`nixos/README.md`** — a pointer to `examples/` added in the "Per-Project Development Environments" section (existing heredocs left in place).
- **`nixos/CLAUDE.md`** — one bullet under "File Locations".

## Notes

- **No committed `flake.lock`.** The first `direnv allow` / `nix develop` generates one; the example README explains that a real project would commit it for byte-for-byte reproducibility.
- These are standalone flakes **not** referenced by the nixos flake, so `nix flake check` / the host dry-run builds never evaluate them — they're only text-formatted by treefmt.

## Remaining / follow-up steps

These need a Nix host (this PR was authored in an environment without `nix`):

- [ ] **Commit `flake.lock` for each example** so contributors get a byte-for-byte identical toolchain:
  ```bash
  cd nixos/examples/python-devshell     && nix flake lock
  cd ../typescript-devshell             && nix flake lock
  git add nixos/examples/*/flake.lock && git commit -m "chore(examples): pin flake.lock"
  ```
- [ ] **Verify each shell loads:** `cd nixos/examples/python-devshell && nix develop -c python hello.py`, and `cd nixos/examples/typescript-devshell && nix develop -c bash -c 'tsc hello.ts && node hello.js'`.
- [ ] **Confirm the `fmt` CI check (treefmt / alejandra) is green.** If it flags the example flakes, run `nix fmt nixos/` and commit — formatting couldn't be verified locally without `nix`.
- [ ] *(Optional)* `direnv allow` in each example dir to confirm auto-load-on-`cd` / unload-on-leave.

## Verification (done in-session)

`python -m py_compile hello.py` passes; the flakes were hand-formatted to match the repo's alejandra style. Authoritative Nix checks are in the follow-up list above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XBAGAamSrYUHPoqXWL4rX