### PR TITLE
feat(dungeon): add the power-watch launchd agent

### DIFF
--- a/nixos/hosts/macs/dungeon/default.nix
+++ b/nixos/hosts/macs/dungeon/default.nix
@@ -182,6 +182,29 @@ in {
     };
   };
 
+  # Detect mains power loss/restoration, alert via Pushover, and Wake-on-LAN Unraid back
+  # up once power returns. Detection works by probing the PoE cameras, which are
+  # deliberately NOT on battery backup — so their reachability IS the mains signal.
+  # Deliberately a plain launchd agent rather than a Grafana rule: Grafana and Prometheus
+  # are containers inside OrbStack, exactly the stack most likely to be degraded during a
+  # power event. This depends on nothing but the network.
+  # Full topology + signal ladder: home-lab/docs/power-outage.md.
+  launchd.user.agents.power-watch = {
+    serviceConfig = {
+      ProgramArguments = [
+        "/bin/bash"
+        "/Users/${vars.user.name}/Git/home-lab/scripts/power-watch.sh"
+      ];
+      RunAtLoad = true;
+      # Every 60s. Far tighter than nfs-stale-check's 5 min because the whole point is to
+      # catch the outage while there is still battery left to act on; the probe is two TCP
+      # connects. A 2-run confirm streak means an edge is declared ~2 min after the event.
+      StartInterval = 60;
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/power-watch.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/power-watch.log";
+    };
+  };
+
   # Deploy oMLX with dungeon-specific settings (8GB hot cache for M3 Pro 36GB).
   # The symlink + jq-merge + restart logic lives in modules/darwin/omlx.nix.
   services.omlxDeploy = {


### PR DESCRIPTION
## Why

Companion to [home-lab#43](https://github.com/GregHilston/home-lab/pull/43), which adds automatic Unraid shutdown on EcoFlow battery plus power-outage alerting. This installs the launchd agent that drives the detection half.

## What it does

`scripts/power-watch.sh` (in home-lab) detects mains loss by probing the PoE cameras — the one thing deliberately left off battery backup, so their reachability *is* the mains signal. On confirmation it sends a Pushover alert; on recovery it sends another plus a Wake-on-LAN packet to Unraid, which a NUT shutdown leaves powered off (the PSU never loses AC, so the BIOS never sees a transition).

## Two deliberate choices

**A launchd agent, not a Grafana alert rule.** Grafana and Prometheus are containers inside OrbStack — during a power event that is precisely the stack most likely to be degraded. This agent depends on nothing but the network, so the alert still goes out when Docker is wedged or stopped.

**`StartInterval = 60`, not 300 like `nfs-stale-check`.** The point is to catch the outage while there is still battery left to act on. The probe is two TCP connects, and the script's 2-run confirm streak means an edge is declared ~2 minutes after the event.

## Testing

Covered by `scripts/tests/power-watch.test.sh` in home-lab (46 assertions, all external dependencies mocked). The agent itself is the standard `ProgramArguments` + `StartInterval` pattern already used by `nfs-stale-check` and `mac-battery-textfile`; `nix fmt` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wnrMos2PXqiZgZbLMfv48
