### PR TITLE
feat(darwin): launch Handy and Ice at login; add two grilling skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,14 +106,25 @@ Handy has to be *running* for the hotkey to do anything, so it's started declara
 rather than by hand: a launchd agent on macOS (`nixos/modules/darwin/handy.nix`, imported
 by citadel and moria — headless dungeon skips it) and a home-manager systemd user service
 bound to `graphical-session.target` on NixOS GUI hosts (`nixos/modules/home/default.nix`).
-Handy's own "Launch at login" toggle stays off; it writes app state nix doesn't own. The
-rationale for the launchd `open -a` shape lives in `nixos/CLAUDE.md` → "Launching GUI apps
-at login".
+Handy's own "Launch at login" toggle stays off; it writes app state nix doesn't own. Ice
+(below) is started the same way — the shared rationale for the launchd `open -a` shape lives
+in `nixos/CLAUDE.md` → "Launching GUI apps at login".
 
 On macOS this only takes effect once Karabiner's driver extension is approved on that
 host — until then Caps Lock still toggles caps. That grant, Handy's mic/accessibility
 grants, and Handy's own hotkey setting are GUI-gated and can't be declared; they're in
 `nixos/docs/darwin-post-deploy.md` (`just checklist`).
+
+## Menu Bar — Ice
+
+[Ice](https://github.com/jordanbaird/Ice) manages the macOS menu bar (hides the overflow
+icons the notch would otherwise swallow). Cask `jordanbaird-ice` in
+`nixos/modules/darwin/homebrew-base.nix`; launched at login by
+`nixos/modules/darwin/ice.nix`, imported from `modules/darwin/common.nix` so all three Macs
+get it. Same pattern as Handy above (`nixos/CLAUDE.md` → "Launching GUI apps at login"): a
+launchd `open -a` agent, `RunAtLoad` only, and Ice's own "Launch at login" toggle stays
+**off** so the two don't double-register. Ice's Accessibility + Screen Recording grants are
+GUI-gated — `nixos/docs/darwin-post-deploy.md`.
 
 ## Dotfiles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,14 @@ transcribes locally (Whisper / Parakeet — audio never leaves the machine).
 Two implementations, one hotkey. macOS: Karabiner-Elements — see `dot/karabiner/`.
 NixOS GUI hosts: `services.keyd` — see `nixos/modules/common/keyd.nix`.
 
+Handy has to be *running* for the hotkey to do anything, so it's started declaratively
+rather than by hand: a launchd agent on macOS (`nixos/modules/darwin/handy.nix`, imported
+by citadel and moria — headless dungeon skips it) and a home-manager systemd user service
+bound to `graphical-session.target` on NixOS GUI hosts (`nixos/modules/home/default.nix`).
+Handy's own "Launch at login" toggle stays off; it writes app state nix doesn't own. The
+rationale for the launchd `open -a` shape lives in `nixos/CLAUDE.md` → "Launching GUI apps
+at login".
+
 On macOS this only takes effect once Karabiner's driver extension is approved on that
 host — until then Caps Lock still toggles caps. That grant, Handy's mic/accessibility
 grants, and Handy's own hotkey setting are GUI-gated and can't be declared; they're in

--- a/claude-skills/grill-me/SKILL.md
+++ b/claude-skills/grill-me/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: grill-me
+description: |
+  Relentlessly interview the user about a plan, design, or architecture to
+  stress-test it — one question per turn, recommending an answer each time.
+  Use when the user wants to be "grilled", wants a plan challenged, says
+  "stress-test my design", "poke holes in this", "what am I missing", "grill me",
+  or presents a plan and asks for critical feedback. Read-only: you interview,
+  you never implement.
+model: inherit
+disallowed-tools: Write, Edit, NotebookEdit
+---
+
+# Grill Me
+
+Interview the user about their plan or design. You are not a reviewer giving
+feedback — you are an interviewer extracting clarity through questions.
+
+## Core protocol
+
+Ask **one question per turn**. For each question, give your **recommended answer**
+so the user can just confirm instead of writing an essay. Wait for the answer
+before moving on. Force the user to articulate undecided decisions, surface hidden
+assumptions, and confront avoided tradeoffs.
+
+Do not: answer your own questions; offer unsolicited solutions (unless framed as
+"why not X instead?"); ask multiple questions at once; validate prematurely
+("sounds great!" is not interviewing); produce a revised plan/spec/implementation.
+
+## Tree-walking strategy
+
+Treat the plan as a decision tree; walk it depth-first: identify top-level
+branches → drill into one until it bottoms out or the user defers → backtrack to
+the next unresolved branch. This avoids dumping 15 questions at once.
+
+## Codebase-first principle
+
+Before asking anything the codebase could answer, check it yourself (Grep/Glob/Read)
+and present what you found as context for a sharper question. Facts are yours to
+look up; decisions are the user's to make.
+
+## Question types
+
+Cycle as appropriate: feasibility, dependency, edge case, alternative, scope,
+ordering, failure mode.
+
+## Session state
+
+Every 5–8 exchanges, pause and summarize: **Resolved**, **Open branches**,
+**Currently drilling into**. Keeps the user oriented and lets them course-correct.
+
+## Termination
+
+Stop when all branches are resolved/deferred, the user says "enough"/"ship it", or
+you have no meaningful questions left. End with a final summary: resolved decisions,
+deferred items, and any open risks you noticed.

--- a/claude-skills/grill-with-docs/ADR-FORMAT.md
+++ b/claude-skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/claude-skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/claude-skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/claude-skills/grill-with-docs/SKILL.md
+++ b/claude-skills/grill-with-docs/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: grill-with-docs
+description: |
+  Relentless interview to sharpen a plan or design that ALSO leaves a paper trail:
+  writes ADRs for hard/surprising/trade-off decisions and maintains a CONTEXT.md
+  glossary of canonical domain terms, inline as you go. Run before building, when
+  the plan is undefined and domain vocabulary is unsettled.
+model: inherit
+disable-model-invocation: true
+allowed-tools: Read, Grep, Glob, Write, Edit
+---
+
+# Grill With Docs
+
+Run a grilling interview (see below) AND capture alignment artifacts as you talk —
+so the shared understanding survives the session. Do not enact the plan until the
+user confirms shared understanding.
+
+## Interview protocol
+
+Interview the user about every aspect of the plan, one question per turn, waiting
+for feedback before continuing (multiple questions at once is bewildering). Walk
+each branch of the design tree depth-first, resolving dependencies between
+decisions one-by-one. For each question, provide your **recommended answer**.
+If a *fact* can be found in the codebase, look it up (Grep/Glob/Read); the
+*decisions* are the user's — put each to them and wait.
+
+## Leave a paper trail (inline, as you go)
+
+**Glossary — `CONTEXT.md`:** when fuzzy language gets sharpened into a canonical
+term, write it to `CONTEXT.md` at the repo root immediately. Keep it a pure
+glossary (no implementation details, no spec). Follow `CONTEXT-FORMAT.md` in this
+skill directory. Flag mismatches between the user's words and the documented terms.
+
+**Decisions — ADRs:** record an ADR in `docs/adr/NNNN-slug.md` **only** when all
+three hold: (1) hard to reverse, (2) surprising without context, (3) the result of
+a real trade-off. Skip otherwise — keep the trail lean. Follow `ADR-FORMAT.md` in
+this skill directory (create `docs/adr/` lazily; number by scanning for the highest
+existing +1).
+
+## Termination
+
+Stop when branches are resolved/deferred or the user says stop. End with a summary
+of resolved decisions, deferred items, ADRs written, and glossary terms added.
+This is the front of the pipeline: grill-with-docs → to-spec → to-tickets → implement.

--- a/dot/karabiner/README.md
+++ b/dot/karabiner/README.md
@@ -69,6 +69,8 @@ behind TCC prompts and per-app state, so nix can't declare any of it.
   login; check it with `launchctl list | grep org.nixos.handy` and read
   `~/Library/Logs/handy.log` if it didn't come up. Leave Handy's own "Launch at login"
   setting off so both aren't registering it. dungeon has the cask but not the agent.
+  Ice (the menu bar manager) is started by the same launchd `open -a` pattern — why it's
+  shaped that way is in `nixos/CLAUDE.md` → "Launching GUI apps at login".
 - **citadel is a work-managed Mac.** If MDM policy blocks driver/system extensions,
   Karabiner won't load there at all. Nothing to do about it from this repo.
 - **Handy stores the binding as `fn+f18`, not `f18`.** That's correct: macOS stamps the

--- a/dot/karabiner/README.md
+++ b/dot/karabiner/README.md
@@ -64,6 +64,11 @@ behind TCC prompts and per-app state, so nix can't declare any of it.
 
 - **Until the driver extension is approved on a host, Karabiner is inert there** and Caps
   Lock keeps toggling caps. On headless **dungeon** that approval needs a VNC session.
+- **Handy launching is declarative, its permissions aren't.** A launchd agent
+  (`nixos/modules/darwin/handy.nix`, on citadel and moria) runs `open -g -j -a Handy` at
+  login; check it with `launchctl list | grep org.nixos.handy` and read
+  `~/Library/Logs/handy.log` if it didn't come up. Leave Handy's own "Launch at login"
+  setting off so both aren't registering it. dungeon has the cask but not the agent.
 - **citadel is a work-managed Mac.** If MDM policy blocks driver/system extensions,
   Karabiner won't load there at all. Nothing to do about it from this repo.
 - **Handy stores the binding as `fn+f18`, not `f18`.** That's correct: macOS stamps the

--- a/nixos/CLAUDE.md
+++ b/nixos/CLAUDE.md
@@ -97,6 +97,34 @@ discord, bitwarden-desktop) are **x86_64-linux only** in nixpkgs — hence the
 `nix eval .#nixosConfigurations.<host>.pkgs.<pkg>.meta.platforms` before adding a GUI app
 for an ARM host.
 
+## Launching GUI apps at login: a launchd `open -a` agent
+
+Menu-bar apps have to already be running to do anything, and they fail *silently* when
+they aren't — no Handy means Caps Lock still behaves and nothing dictates; no Ice means
+the stock cluttered menu bar. So each gets a launchd user agent: `modules/darwin/handy.nix`
+(imported per-host by citadel and moria; headless dungeon has the cask but no use for a
+dictation app) and `modules/darwin/ice.nix` (imported from `modules/darwin/common.nix`, so
+all three Macs). The Linux equivalent is a home-manager `systemd.user.services.*` unit
+bound to `graphical-session.target` — see handy in `modules/home/default.nix`.
+
+The shape is always the same, and *why* is the part worth remembering:
+
+- **`/usr/bin/open -g -j -a /Applications/Foo.app`, not the bundle's inner binary.** macOS
+  TCC keys Microphone/Accessibility/Screen-Recording grants on a LaunchServices launch, so
+  `open` is what a double-click does and the grants from `docs/darwin-post-deploy.md`
+  survive. It's also idempotent — `open -a` on a running app just activates it, so the
+  agent bootstrap on every `just dr <host>` can't leave two copies running. `-g` = don't
+  steal focus, `-j` = launch hidden.
+- **`RunAtLoad` only, never `KeepAlive`.** `open` exits as soon as LaunchServices takes
+  over, so KeepAlive reads that as a crash and respawns forever. The tradeoff: a real
+  crash isn't restarted. Fine — the missing menu-bar icon is the tell.
+- **Not the app's own "Launch at login" toggle.** Those register an `SMAppService` login
+  item in app-written state (e.g. Handy's `settings_store.json`) that nix neither owns nor
+  can assert. Keep the in-app toggle **off** so the two don't double-register.
+- **Log to `~/Library/Logs/<app>.log`.** On a fresh host the agent can load before Homebrew
+  installs the cask; `Unable to find application named ...` shows up there rather than
+  failing the rebuild.
+
 ## Common Mistakes to Avoid
 
 1. **Module imports**: Always use relative paths in module imports (e.g., `../../modules/home` not absolute paths)

--- a/nixos/docs/darwin-post-deploy.md
+++ b/nixos/docs/darwin-post-deploy.md
@@ -47,6 +47,9 @@ per-host caveats: `dot/karabiner/README.md`.
 - [ ] **Handy** - grant Microphone and Accessibility (needed to paste into the focused app),
       then download a model: Parakeet V3 (CPU-efficient English) or Whisper Turbo/Large
       (better accuracy, 100+ languages)
+      > Starting Handy is *not* a manual step: `modules/darwin/handy.nix` launches it at
+      > login (`launchctl list | grep org.nixos.handy`). Leave Handy's own "Launch at
+      > login" setting off so the two don't both register it.
 - [ ] **Handy hotkey** - set the binding to `F18` by *holding* Caps Lock while the picker is
       capturing, and leave push-to-talk mode on (its default). It will display and store this
       as `fn + F18` — that's correct, macOS flags all F-keys with `fn`

--- a/nixos/docs/darwin-post-deploy.md
+++ b/nixos/docs/darwin-post-deploy.md
@@ -60,4 +60,10 @@ per-host caveats: `dot/karabiner/README.md`.
 ## Launch Applications
 
 - [ ] Set up AeroSpace tiling
-- [ ] Configure Bartender menu bar layout
+- [ ] **Ice** (menu bar manager, replaced Bartender) - it's launched at login by the launchd
+      agent in `modules/darwin/ice.nix`, but its permissions are GUI-gated: on first launch
+      approve Accessibility (move/hide menu bar items) and Screen Recording (item search and
+      menu bar appearance). Leave Ice's own Settings → General → "Launch Ice at login"
+      **off** — the launchd agent owns that, and both would double-register.
+- [ ] Arrange the menu bar in Ice: drag icons above/below the divider with ⌘-drag to choose
+      what stays visible vs. hidden

--- a/nixos/hosts/macs/citadel/default.nix
+++ b/nixos/hosts/macs/citadel/default.nix
@@ -8,6 +8,9 @@
     ../../../modules/darwin/home.nix
     ../../../modules/darwin/homebrew-base.nix
     ../../../modules/darwin/omlx.nix
+    # Launch Handy at login so the Caps-Lock-hold → F18 dictation hotkey works
+    # without opening the app by hand.
+    ../../../modules/darwin/handy.nix
   ];
 
   networking.hostName = "citadel";

--- a/nixos/hosts/macs/moria/default.nix
+++ b/nixos/hosts/macs/moria/default.nix
@@ -9,6 +9,9 @@
     ../../../modules/darwin/homebrew-server.nix
     ../../../modules/darwin/home.nix
     ../../../modules/darwin/omlx.nix
+    # Launch Handy at login so the Caps-Lock-hold → F18 dictation hotkey works
+    # without opening the app by hand.
+    ../../../modules/darwin/handy.nix
   ];
 
   networking.hostName = "moria";

--- a/nixos/modules/darwin/common.nix
+++ b/nixos/modules/darwin/common.nix
@@ -5,6 +5,12 @@
 }: let
   basePackages = import ../../config/base-packages.nix pkgs;
 in {
+  imports = [
+    # Launch Ice (menu bar manager) at login. Here rather than per-host because
+    # every Mac gets the cask from ./homebrew-base.nix and wants it running.
+    ./ice.nix
+  ];
+
   # Let Determinate manage the Nix daemon; disable nix-darwin's nix management
   nix.enable = false;
 

--- a/nixos/modules/darwin/handy.nix
+++ b/nixos/modules/darwin/handy.nix
@@ -1,0 +1,27 @@
+# Launch Handy at login (macOS half of "hold Caps Lock to dictate").
+#
+# Handy is a menu-bar app, so it has to already be running for the F18 that
+# Karabiner emits on a Caps Lock hold to land anywhere. Without this you get a
+# silent failure mode: Caps Lock behaves correctly, nothing dictates.
+#
+# Why an `open -a` agent instead of the inner binary, why no KeepAlive, and why
+# not Handy's own `autostart_enabled` setting: nixos/CLAUDE.md → "Launching GUI
+# apps at login". Handy is one of two users of that pattern; ./ice.nix is the
+# other. The cask itself is in ./homebrew-base.nix; the Linux half is the systemd
+# user service in ../home/default.nix.
+#
+# Handy-specific: imported per-host (citadel, moria) rather than from
+# ./common.nix, because headless dungeon has no microphone or interactive user to
+# dictate for. Add the import to its host file if that ever changes.
+{vars, ...}: {
+  launchd.user.agents.handy = {
+    command = "/usr/bin/open -g -j -a /Applications/Handy.app";
+    serviceConfig = {
+      RunAtLoad = true;
+      # Where "Unable to find application named 'Handy'" shows up if the cask
+      # hasn't installed yet on a fresh host.
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/handy.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/handy.log";
+    };
+  };
+}

--- a/nixos/modules/darwin/homebrew-base.nix
+++ b/nixos/modules/darwin/homebrew-base.nix
@@ -85,7 +85,8 @@
       # the F18 that Karabiner emits. Both are casks rather than nixpkgs on
       # purpose: macOS TCC permissions key on the binary path, so a nix-store app
       # re-prompts for Microphone/Accessibility on every rebuild. NixOS gets the
-      # same pair from nixos/modules/common/handy.nix (keyd + nixpkgs handy).
+      # same pair from nixos/modules/common/keyd.nix (the remap) and the GUI block
+      # in nixos/modules/home/default.nix (nixpkgs handy + its user service).
       "karabiner-elements"
       "handy"
 

--- a/nixos/modules/darwin/ice.nix
+++ b/nixos/modules/darwin/ice.nix
@@ -1,0 +1,29 @@
+# Launch Ice at login on every Mac.
+#
+# Ice (jordanbaird-ice) is a menu bar manager: it hides the overflow icons that
+# macOS otherwise silently drops behind the notch. It's a menu-bar-only app
+# (LSUIElement = true in its Info.plist), so if it isn't running you don't get an
+# error, you just get the stock cluttered menu bar back.
+#
+# Why an `open -a` agent instead of the inner binary, why no KeepAlive, and why
+# not Ice's own Settings → General → "Launch Ice at login" toggle: nixos/CLAUDE.md
+# → "Launching GUI apps at login". Ice is one of two users of that pattern;
+# ./handy.nix is the other. The cask itself is in ./homebrew-base.nix.
+#
+# Ice-specific: imported from ./common.nix so all three Macs (moria, dungeon,
+# citadel) get it without a per-host import — even headless dungeon has a menu bar
+# worth managing over VNC. Contrast ./handy.nix, per-host on purpose. Ice's grants
+# are Accessibility (move/hide items) + Screen Recording (item search, menu bar
+# appearance); see docs/darwin-post-deploy.md.
+{vars, ...}: {
+  launchd.user.agents.ice = {
+    command = "/usr/bin/open -g -j -a /Applications/Ice.app";
+    serviceConfig = {
+      RunAtLoad = true;
+      # Where "Unable to find application named 'Ice'" shows up if the cask
+      # hasn't installed yet on a fresh host.
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/ice.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/ice.log";
+    };
+  };
+}

--- a/nixos/modules/home/default.nix
+++ b/nixos/modules/home/default.nix
@@ -83,6 +83,33 @@ in {
       spotify
     ]);
 
+  # Launch Handy with the graphical session (Linux half of "hold Caps Lock to
+  # dictate"; the macOS half is a launchd agent in ../darwin/handy.nix). Handy is
+  # a tray app and has to already be running for the F18 that keyd emits on a
+  # Caps Lock hold to land anywhere — otherwise Caps Lock behaves correctly and
+  # nothing dictates. Same enableGui gate as the package itself above.
+  #
+  # graphical-session.target, not default.target: Handy is webkitgtk + a tray
+  # icon, so it needs a display and a running status-notifier host. PartOf ties
+  # it to the session so it stops on logout instead of lingering.
+  #
+  # Untested on Linux, like the keyd half — see ../common/keyd.nix's note.
+  systemd.user.services.handy = lib.mkIf enableGui {
+    Unit = {
+      Description = "Handy — local speech-to-text, push-to-talk on F18";
+      After = ["graphical-session.target"];
+      PartOf = ["graphical-session.target"];
+    };
+    Service = {
+      ExecStart = "${pkgs.handy}/bin/handy";
+      # Plasma can bring the tray up slightly after the target, so give a failed
+      # start a few retries rather than leaving dictation dead until next login.
+      Restart = "on-failure";
+      RestartSec = 5;
+    };
+    Install.WantedBy = ["graphical-session.target"];
+  };
+
   # Install the searxngr binary via uv. The config itself is stowed on both
   # platforms by ./workstation.nix; on Darwin this install stays manual.
   home.activation.install-searxngr = lib.hm.dag.entryAfter ["installPackages"] ''

--- a/nixos/modules/programs/tui/zsh/default.nix
+++ b/nixos/modules/programs/tui/zsh/default.nix
@@ -58,7 +58,7 @@
     # no ~/.zshrc / ~/.tmux.conf (and thus a bare prompt). The old /opt/homebrew/bin
     # PATH hack only rescued Darwin. ${pkgs.stow}/bin/stow works everywhere.
     # karabiner is Darwin-only (the Caps-Lock-to-dictation remap; NixOS uses keyd
-    # in modules/common/handy.nix instead). Stow folds ~/.config/karabiner into a
+    # in modules/common/keyd.nix instead). Stow folds ~/.config/karabiner into a
     # single directory symlink, which is what Karabiner requires — see
     # dot/karabiner/README.md for why, and how to recover if it already exists.
     if [ -d "$DOTFILES" ]; then


### PR DESCRIPTION
Two unrelated threads that happened to be in the same working tree, kept as separate commits.

## Launch Handy and Ice at login

Both are menu-bar apps that fail *silently* when they aren't running — no Handy means Caps
Lock behaves correctly and nothing dictates; no Ice means the stock menu bar with the icons
the notch swallows. Starting them was the last manual step in an otherwise declarative
setup.

Each gets a launchd user agent, and the shared reasoning is written up once in
`nixos/CLAUDE.md` → "Launching GUI apps at login":

- `/usr/bin/open -g -j -a` rather than the bundle's inner binary, so macOS TCC keeps the
  Microphone / Accessibility / Screen Recording grants attached to a LaunchServices launch.
- `RunAtLoad` without `KeepAlive` — `open` exits as soon as LaunchServices takes over, so
  KeepAlive would read that as a crash and respawn forever.
- The app's own "Launch at login" toggle stays **off**: it registers an `SMAppService` item
  in app-written state nix can't assert, and both would double-register.

Scoping differs on purpose. Handy is imported per-host (citadel, moria) — headless dungeon
has the cask but no microphone or interactive user. Ice comes from
`modules/darwin/common.nix`, so all three Macs get it; even dungeon has a menu bar worth
managing over VNC. NixOS GUI hosts get the Handy equivalent, a home-manager systemd user
service bound to `graphical-session.target`.

## Two grilling skills

`grill-me` interviews you about a plan one question per turn, each with a recommended answer
so confirming is cheaper than writing an essay, walking the design depth-first rather than
dumping fifteen questions at once. Read-only by construction.

`grill-with-docs` runs the same interview but leaves a paper trail as it goes: a `CONTEXT.md`
glossary when fuzzy language gets sharpened into a canonical term, and an ADR only when a
decision is hard to reverse, surprising, *and* a real trade-off.

## Verification

`nix build --dry-run` on all three Darwin hosts. citadel and moria produce both
`org.nixos.handy.plist` and `org.nixos.ice.plist`; dungeon produces Ice only, as intended.
The Linux half evaluates on mines (`systemd.user.services.handy` resolves to
`handy-0.9.0/bin/handy`).

Nothing is deployed — `just dr <host>` still has to be run per Mac, and Ice's Accessibility
and Screen Recording grants are GUI-gated (they're in the `just checklist` output).
