### PR TITLE
feat(dungeon): add the port-sync-check launchd agent

### DIFF
--- a/nixos/hosts/macs/dungeon/default.nix
+++ b/nixos/hosts/macs/dungeon/default.nix
@@ -205,6 +205,34 @@ in {
     };
   };
 
+  # Detect drift between ProtonVPN's forwarded port and Transmission's peer-port, and
+  # re-run the sync that should have run on its own.
+  #
+  # gluetun's up-command pages when it RUNS AND FAILS. It cannot cover the up-command not
+  # running at all — nothing failed, so nothing alerts, while Transmission listens on a port
+  # Proton no longer forwards and receives no inbound peers. Confirmed 2026-08-13: a gluetun
+  # restart stranded the netns members, the sync failed against an unreachable RPC, and
+  # Proton then handed back THE SAME PORT — so the up-command never fired again and the
+  # staleness had nothing watching it.
+  #
+  # 15 min, not 5: the condition is silent-but-not-urgent (inbound peers only), the probe
+  # costs two `docker exec`s, and the script itself confirms drift over 2 consecutive runs
+  # before acting — so a real drift is healed within ~30 min while a reconnect's brief,
+  # legitimate mismatch is never mistaken for one.
+  # Rationale + failure modes: home-lab/docs/runbooks/proton-port-sync-failed.md.
+  launchd.user.agents.port-sync-check = {
+    serviceConfig = {
+      ProgramArguments = [
+        "/bin/bash"
+        "/Users/${vars.user.name}/Git/home-lab/scripts/port-sync-check.sh"
+      ];
+      RunAtLoad = true;
+      StartInterval = 900;
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/port-sync-check.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/port-sync-check.log";
+    };
+  };
+
   # Deploy oMLX with dungeon-specific settings (8GB hot cache for M3 Pro 36GB).
   # The symlink + jq-merge + restart logic lives in modules/darwin/omlx.nix.
   services.omlxDeploy = {


### PR DESCRIPTION
Adds the `port-sync-check` launchd agent on dungeon, running
`home-lab/scripts/port-sync-check.sh` every 15 minutes.

## Why

gluetun's port-forward up-command pages when it **runs and fails**. It cannot cover the
up-command **not running at all** — nothing failed, so nothing alerts, while Transmission
listens on a port ProtonVPN no longer forwards and receives no inbound peers. `home-lab`
carried this as a known "Residual gap" with the fix already specified.

It stopped being hypothetical on 2026-08-13: restarting gluetun stranded its netns members,
the up-command fired against an unreachable RPC and failed, and Proton then handed back
**the same port** on reconnect — so it never fired again. "It fixes itself on the next port
event" is false whenever the port does not change, and nothing was watching.

## Why 15 minutes

Deliberately looser than `nfs-stale-check` (5 min) and `power-watch` (60 s):

- the condition is silent-but-not-urgent — it costs inbound peers, nothing else
- the probe is two `docker exec`s
- the script confirms drift over **2 consecutive runs** before acting, because a reconnect
  briefly looks identical to drift and healing that window fires a pointless tracker
  re-announce

So a real drift heals within ~30 min, and a legitimate transient is never mistaken for one.

## Safety

The script stands down with no alert during a mains outage, an unresponsive Docker, a missing
gluetun/transmission, or an unhealthy tunnel — each already has its own alert. Pushover
priority is clamped to a 0 ceiling, so it cannot bypass quiet hours.

## Verification

The script side is merged in `home-lab` (`bb1338b`) with 50 test assertions, and was verified
end-to-end against the live stack: induced real drift (peer-port 51999 vs forwarded 33022),
run 1 debounced, run 2 healed and alerted, run 3 reported in sync, `port-is-open: true`
afterwards.

`nix-instantiate --parse` passes. **Not yet activated** — needs `just dr dungeon`.
