### PR TITLE
feat(omlx): pick Qwen3.6-35B-A3B-4bit as the local coding default

### DIFF
--- a/docs/local-llm-benchmarks.md
+++ b/docs/local-llm-benchmarks.md
@@ -8,34 +8,32 @@ decoding, and long-context prefill.
 reproducible harness lives in `dot/omlx/bench/`; the earlier MoE-only speculative-decoding
 work is in `dot/omlx/speculative-decoding-findings.md`.
 
----
-
 ## Executive summary
 
 1. **The MoE won. `Qwen3.6-35B-A3B-4bit` is the default coding model** — 130.7 tok/s decode
-   vs the dense `Qwen3.8-27B-4bit`'s 23.0 (**5.7×**), and it scored **9/10 vs 8/10** on an
-   executable coding eval. Faster *and* not worse, so there is no trade to agonise over.
+   vs the dense `Qwen3.8-27B-4bit`'s 23.0 (**5.7×**), 6.6–10.0× faster prefill, and it scored
+   **9/10 vs 8/10** on an executable coding eval. Faster *and* not worse.
 2. **The newer, higher-benchmarked dense model is the slow specialist.** Qwen3.8-27B is a
    newer generation with better published scores, but we could not measure a quality
-   advantage — our eval hits a ceiling. Its real edge is **token efficiency**: it solved the
-   eval with 31.8k tokens vs A3B's 84.1k (2.6× fewer).
-3. **On a *dense* model, 8-bit costs ~2× the speed for nothing.** 23.0 → 11.9 tok/s. On a
-   *MoE* it costs only 1.50× (130.7 → 86.9), because a MoE only reads its ~3B active params.
-   The "I have 128 GB so take the 8-bit" instinct is wrong on both, and *most* wrong on dense.
-   No 6-bit exists for these models.
-4. **Qwen3.8-27B is a retrain on the identical Qwen3.6-27B skeleton** — same config,
-   byte-identical 14.95 GiB weights, same measured speed. Free upgrade, old one deleted.
-5. **Qwen3.8's `reasoning_effort` defaults to `xhigh`, which is unusable.** Unconfigured it
-   burned 8,000 tokens over 401 s and *never produced an answer*. Worse, **more thinking made
-   it worse**: `medium` scored 8/10 in 27 min; `xhigh` scored 6/10 in 111 min.
+   advantage — our eval ceilings out. Its real edge is **token efficiency**: 31.8k tokens vs
+   A3B's 84.1k to solve the same suite (2.6× fewer).
+3. **On a *dense* model, 8-bit costs ~2× the speed for nothing.** 23.0 → 11.9 tok/s. On the
+   *MoE* it costs 1.50× (130.7 → 86.9), because a MoE only reads its ~3B active params.
+   The "I have 128 GB so take the 8-bit" instinct is wrong on both. No 6-bit MLX quant is
+   published for either model.
+4. **Qwen3.8-27B is a retrain on the Qwen3.6-27B skeleton** — same architecture config,
+   identically-sized 14.95 GiB weights, same measured speed. Free upgrade, old one deleted.
+5. **Qwen3.8's `reasoning_effort` defaults to `xhigh`, which never terminates.** Unconfigured
+   it burned 8,000 tokens over 401 s and produced no answer at all. `medium` scored 8/10 in
+   27 min; `xhigh` scored 6/10 in 111 min — every extra failure was a truncation.
 6. **Speculative decoding finally pays off on a dense model (1.43× on code) — but oMLX's
-   implementation is not bit-identical**, verified against a determinism control. Left off.
-7. **Prefill, not decode, is what you wait for** — and it is where the MoE's lead is widest:
-   a 64K context costs A3B 64 s versus the dense model's 291 s.
+   implementation is not bit-identical** against a determinism control. Left disabled.
+7. **Prefill, not decode, is what you wait for**, and it is where the MoE's lead is widest
+   (6.6–10.0× vs 5.7× on decode). A 64K context costs the dense model **8.5 minutes** to
+   first token, versus 77 seconds for the MoE.
 
-**Practical rule:** default to A3B-4bit. Reach for Qwen3.8-27B-4bit only when A3B has
-actually failed a specific hard problem, or when output tokens are precious. Expect to wait
-~5.7× longer when you do.
+**Practical rule:** default to A3B-4bit. Reach for Qwen3.8-27B-4bit only when A3B has actually
+failed a specific hard problem, or when output tokens are precious. Expect ~5.7× the wait.
 
 ---
 
@@ -57,31 +55,161 @@ actually failed a specific hard problem, or when output tokens are precious. Exp
 later. Absolute numbers carry roughly ±20%; only ratios measured within a single pass are
 trustworthy. Do not compare these numbers across sessions or against other machines.
 
-## Test parameters
+---
 
-| test | parameters |
-|---|---|
-| **Throughput** | temperature 0 (greedy), 200 completion tokens, 3 reps, **median** reported. Three prompt families: code (458 prompt tok), prose (182), qa (179). `decode = completion_tokens / (wall − TTFT)` |
-| **Coding eval** | 10 original tasks (written fresh, not HumanEval/MBPP) each with a hidden executable test suite; pass = every assertion holds. temp 1.0 / top_p 0.95 / top_k 20, `max_tokens` 16000, 1 rep per task |
-| **Long-context** | thinking disabled, output capped at 24 tokens so wall ≈ prefill. Synthetic source-like prompt repeated to length |
-| **reasoning_effort** | one fixed debugging question, temp 1.0 / top_p 0.95 / top_k 20, `max_tokens` 8000 |
-| **Speculative decoding** | matched A/B on one server instance, temp 0, 200 tokens, 3 reps |
-| **Losslessness** | temp 0, 3 fixed prompts, SHA-256 of `reasoning_content` + `content`, drafter off vs on, **plus a control** (off vs off across a restart) |
+## What each benchmark measures, how, and how to read it
 
-**Protocol.** oMLX is restarted before *every* measured model so exactly one is resident, and
-each window is audited against the server log for foreign traffic. Both of those controls
-exist because skipping them produced wrong numbers — see the confounds section.
+Every number below is defined here so a high or low score can be interpreted rather than
+just compared.
+
+### 1. Decode throughput (tok/s) — *higher is better*
+
+**What:** sustained generation rate once the prompt has been processed — how fast words appear.
+
+**How:** streaming request, 200 completion tokens, temperature 0, 3 repetitions. Computed as
+`usage.completion_tokens / (wall − TTFT)`, i.e. tokens divided by the post-prefill span. We
+report the **median of 3 runs per prompt family** (code / prose / qa), then the **mean of
+those three family medians** as the headline figure.
+
+**Why it matters:** this is the dominant cost for long answers, and for a *dense* model it is
+memory-bandwidth-bound — decode time tracks total weight bytes almost exactly. That is the
+whole reason quantization choice matters so much on dense models and less on MoE.
+
+**Reading it:** below ~20 tok/s feels sluggish for interactive work (you watch it type);
+above ~80 tok/s feels essentially instant. A ratio between two models is far more reliable
+than either absolute number on this machine.
+
+**Trap:** oMLX packs several tokens into one SSE chunk, so counting chunks is *not* counting
+tokens. Doing that once produced a nonsensical "7 tok/s decode" against a 22 tok/s end-to-end
+rate. The harness now hard-fails rather than falling back to chunk counts.
+
+### 2. TTFT — time to first token (seconds) — *lower is better*
+
+**What:** latency from sending the request to the first token appearing. Almost entirely
+prefill plus queueing.
+
+**How:** wall time to the first streamed content chunk, from the same runs as decode.
+
+**Why it matters:** this is the pause you *feel* before anything happens. Decode throughput
+says nothing about it.
+
+**Reading it:** under ~1 s feels responsive; several seconds on a short prompt signals an
+expensive prefill path, and it will scale badly with context.
+
+### 3. Prefill throughput (tok/s) — *higher is better*
+
+**What:** the rate at which the model ingests your prompt.
+
+**How:** measured directly by `longctx.py` — thinking disabled and output capped at 24 tokens
+so wall-clock ≈ prefill. Prompt sizes ~2K to ~64K tokens.
+
+**Why it matters:** for agentic coding this dominates everything. You paste a large repo
+context and wait. Decode speed is irrelevant until prefill finishes.
+
+**Reading it:** watch both the *rate* and the *shape*. Roughly flat or gently declining with
+length is good (attention cost is not blowing up); a collapsing curve means quadratic
+behaviour. Both models here scale roughly linearly, which is the hybrid attention working —
+only 16 of 64 (dense) and 10 of 40 (MoE) layers keep a real KV cache.
+
+**Trap — this one invalidated our first attempt.** oMLX runs a prefix cache. Building each
+prompt as `header + filler×N + question` and walking sizes in ascending order makes every
+prompt a strict prefix-extension of the last, so most of the prefill is served from cache.
+The tell was unmistakable: a 7,862-token prompt returned *faster* in wall-clock than a
+1,946-token one. The harness now puts a unique random nonce in the first line of every
+prompt, shuffles the size order, warms up first, and asserts `cached_tokens == 0` on every
+row. All prefill figures below are from the corrected run.
+
+### 4. Coding eval pass rate (x/10) — *higher is better, but see the caveat*
+
+**What:** fraction of 10 original coding tasks whose hidden assertion suite passes.
+
+**How:** each task states a precise spec; the model emits a fenced Python block; we `exec` it
+and run assertions it never saw. Pass = every assertion holds. No judging, no rubric, no
+partial credit. Tasks were written fresh rather than taken from HumanEval/MBPP to limit
+training-set contamination, and all ten were validated against reference solutions first, so
+a failure means the model got it wrong and not that the harness is broken.
+
+**Why it matters:** it is objective and it tests the thing we actually care about — following
+a precise spec and handling edge cases, not producing plausible-looking code.
+
+**Reading it — the important part:** with n=10, **a one-task difference is noise.** 9/10 vs
+8/10 establishes "not worse", never "better". Both models here also sit near the ceiling of
+this suite, which is precisely when a benchmark stops discriminating. Only a gap of several
+tasks would be meaningful, and we do not have one.
+
+### 5. Truncation count — *lower is better*
+
+**What:** how many tasks hit the token cap (`finish_reason: length`) instead of finishing.
+
+**How:** recorded separately from pass/fail, because they mean different things.
+
+**Why it matters:** a truncation is a **configuration** failure, not a capability failure —
+the model ran out of room, it did not get the answer wrong. Conflating the two makes a badly
+configured model look stupid. Note truncation is not automatically a failure: one run hit the
+cap and still passed, because the fenced code block landed before the cutoff.
+
+**Reading it:** high truncation counts mean your `reasoning_effort` / thinking budget is
+wrong. That is a knob, not a verdict on the model.
+
+### 6. Tokens spent, and wall-clock for the suite — *lower is better*
+
+**What:** total completion tokens to solve all 10 tasks, and the end-to-end time to do it.
+
+**Why it matters:** tokens measure verbosity; wall-clock measures your actual experience and
+combines speed *and* verbosity. A model can be slow per token but terse enough to win, or
+fast but so rambling it loses. Wall-clock is arguably the single most honest headline metric.
+
+**Reading it:** only meaningful *alongside* pass rate. Fewer tokens at equal quality is
+strictly better; fewer tokens at lower quality is just a worse model.
+
+### 7. Draft acceptance (speculative decoding) — *higher is better*
+
+**What:** the fraction of speculatively drafted tokens the target model accepts, and the mean
+tokens emitted per verification round.
+
+**How:** read from oMLX's own `vlm_mtp stats` log lines.
+
+**Why it matters:** it predicts speedup — but **not on its own.** Every rejected token is
+wasted verify compute, so acceptance has to be weighed against the cost of the verify pass.
+High acceptance on a model whose decode isn't bandwidth-bound still yields no speedup, which
+is exactly why this technique lost on our Gemma MoE and wins on the dense 27B.
+
+### 8. Losslessness (hash identity) — *identical is required, not merely desirable*
+
+**What:** whether enabling an optimization changes the output at all.
+
+**How:** SHA-256 over `reasoning_content + content` at temperature 0 for 3 fixed prompts, with
+the optimization off vs on — **plus a control**: off vs off, across a server restart.
+
+**Why it matters:** speculative decoding with greedy verification is supposed to be
+*bit-identical* to plain decoding. That is the entire appeal: free speed, no quality
+question. If output changes, you are silently trading quality for speed and you no longer
+know what you are running.
+
+**Reading it:** the control is not optional. Without it you cannot distinguish a real
+divergence from ordinary nondeterminism, and a "failed" losslessness test would be
+uninterpretable.
+
+### 9. Quantization penalty (ratio) — *lower is better*
+
+**What:** decode speed at 4-bit ÷ decode speed at 8-bit for the same model.
+
+**Why it matters:** it tells you what a quantization level costs *on this architecture*,
+which is not a constant. On a dense model it should approximate the weight-byte ratio; on a
+MoE it should be smaller, because only the active experts are read per token.
+
+**Reading it:** a penalty near the weight-byte ratio means you are purely bandwidth-bound. A
+much smaller penalty (our MoE, 1.50× against a 1.84× byte ratio) confirms the active-parameter
+story. It is never *zero*, which is the part people assume wrongly.
 
 ---
 
 ## Results: throughput
 
-Decode is the sustained generation rate; TTFT is time-to-first-token on the 458-token code
-prompt.
-
-| model | type | active params | quant | on disk | **decode tok/s** | TTFT |
+| model | type | active | quant | on disk | **decode tok/s** | TTFT |
 |---|---|---|---|---|---|---|
 | **Qwen3.6-35B-A3B-4bit** | MoE | ~3B | 4-bit | 19 GB | **130.73** | 0.50 s |
+| Qwen3.6-35B-A3B-4bit-DWQ | MoE | ~3B | 4-bit DWQ | 19 GB | 103.64 | 0.52 s |
 | Qwen3.6-35B-A3B-8bit | MoE | ~3B | 8-bit | 35 GB | 86.91 | 0.54 s |
 | Qwen3.6-27B-4bit | dense | 27B | 4-bit | 14.95 GiB | 24.01 | 2.51 s |
 | **Qwen3.8-27B-4bit** | dense | 27B | 4-bit | 14.95 GiB | **22.96** | 2.58 s |
@@ -90,49 +218,46 @@ prompt.
 
 Per-family medians for the two finalists:
 
-| model | code | prose | qa | avg |
+| model | code | prose | qa | mean |
 |---|---|---|---|---|
 | Qwen3.6-35B-A3B-4bit | 132.61 | 130.66 | 128.92 | **130.73** |
 | Qwen3.8-27B-4bit | 23.86 | 22.91 | 22.11 | **22.96** |
 
-**Quantization cost, by architecture:**
+**Quantization penalty by architecture:**
 
-| architecture | 4-bit | 8-bit | penalty |
-|---|---|---|---|
-| dense 27B (Qwen3.8) | 22.96 | 11.93 | **1.92×** |
-| dense 27B (Qwen3.6) | 24.01 | 11.98 | **2.00×** |
-| MoE 35B-A3B (Qwen3.6) | 130.73 | 86.91 | **1.50×** |
+| architecture | 4-bit | 8-bit | penalty | weight-byte ratio |
+|---|---|---|---|---|
+| dense 27B (Qwen3.8) | 22.96 | 11.93 | **1.92×** | 1.84× |
+| dense 27B (Qwen3.6) | 24.01 | 11.98 | **2.00×** | 1.84× |
+| MoE 35B-A3B (Qwen3.6) | 130.73 | 86.91 | **1.50×** | 1.84× |
 
-A dense model re-reads every parameter each decode step, so time tracks weight bytes (ratio
-27.48/14.95 = 1.84; the excess is KV-cache and activation traffic that doesn't shrink). A MoE
-reads only its active experts, so 8-bit hurts less — but it still is not free, which is the
-part people get wrong.
+The dense penalty tracks the weight-byte ratio closely (the excess is KV-cache and activation
+traffic that does not shrink). The MoE penalty is materially smaller because only the active
+experts are read — but it is not free, which is the widely-assumed-wrong part.
 
 ## Results: coding eval
 
-10 original tasks, executable tests. Four of the ten suites were validated against reference
-solutions first, so a failure means the model got it wrong, not that the harness is broken.
-
 | model | config | **pass** | truncated | tokens | wall-clock | effective tok/s |
 |---|---|---|---|---|---|---|
+| Qwen3.6-35B-A3B-4bit-**DWQ** | temp 1.0 | **10/10** | 1 | 87,777 | 19.1 min | 76.6 |
 | **Qwen3.6-35B-A3B-4bit** | temp 1.0 | **9/10** | 1 | 84,062 | **17.4 min** | 80.6 |
 | Qwen3.8-27B-4bit | `reasoning_effort: medium` | 8/10 | 1 | 31,849 | 27.1 min | 19.6 |
 | Qwen3.6-27B-4bit | default (no effort knob) | 8/10 | 3 | 105,207 | 90.7 min | 19.3 |
 | Qwen3.8-27B-4bit | `reasoning_effort: xhigh` | 6/10 | 4 | 123,418 | 111.5 min | 18.4 |
 
-Each model is shown at the best configuration found for it. The MoE finishes the whole suite
-in 17 minutes; the dense model's best run takes 27, and its *maximum-effort* run takes 111
-minutes to score two points lower.
+Each model is shown at the best configuration found for it. The MoE finishes the suite in 17
+minutes; the dense model's best run takes 27, and its *maximum-effort* run takes 111 minutes
+to score two points lower.
 
-**Read the quality column carefully.** 9-vs-8 on ten tasks is one task — that is noise, not a
-demonstrated quality difference, and both are near the ceiling of this eval, which is exactly
-when a benchmark stops discriminating. The honest claim is *"the MoE was not worse"*, not
-*"the MoE is better"*. The **5.7× speed difference is not noise.**
+**Apply the n=10 caveat consistently.** 9-vs-8 is one task and does not establish a quality
+difference — nor does 10-vs-9 for DWQ. What *is* solidly established here is the 5.7× speed
+gap, and that unset/`xhigh` **never terminates** (`finish_reason: length` at 401 s and 405 s,
+zero characters of `reasoning_content`) at 4× the wall-clock. The `medium`-vs-`xhigh` gap is
+two tasks with a mechanistic explanation (truncation), which makes it *suggestive* rather
+than proven — but pinning `medium` needs only the non-termination result, which is
+unambiguous.
 
-The 8-vs-6 gap between `medium` and `xhigh` **on the same model and same tasks** is much
-better founded, because the failure mode is mechanical and identifiable (truncation).
-
-## Results: `reasoning_effort` (Qwen3.8 only — new in 3.8, absent in 3.6)
+## Results: `reasoning_effort` (new in Qwen3.8; absent in Qwen3.6)
 
 The chat template defaults it to `xhigh` (`chat_template.jinja:47`). One debugging question,
 8000-token cap:
@@ -149,34 +274,38 @@ Unset and explicit `xhigh` behave identically, confirming the default. A side ef
 knowing: because `</think>` never arrives, the parser cannot split reasoning from content, so
 all ~36k characters land in `content` and `reasoning_content` comes back empty.
 
-Practical ordering on this hardware: **`medium` > `low` ≫ `xhigh` (the shipped default)**.
+## Results: long-context prefill (corrected)
 
-## Results: long-context prefill
+**These numbers replace an earlier contaminated set** — see trap #3 above. Every row below was
+verified `cached_tokens == 0`.
 
-For an agent, felt latency is usually prefill — you send a big context and wait. Decode tok/s
-says nothing about it. This is where the MoE's advantage is widest.
-
-| prompt tokens | A3B-4bit wall | A3B tok/s | Qwen3.8-27B-4bit wall | dense tok/s | **speedup** |
+| prompt tokens | A3B-4bit | A3B tok/s | Qwen3.8-27B-4bit | dense tok/s | **MoE speedup** |
 |---|---|---|---|---|---|
-| 1,946 | 7.1 s | 273 | 15.5 s | 125 | 2.2× |
-| 7,862 | 5.4 s | 1,451 | 48.8 s | 161 | 9.0× |
-| 15,866 | 10.4 s | 1,532 | 63.5 s | 250 | 6.1× |
-| 31,874 | 24.2 s | 1,320 | 127.7 s | 250 | 5.3× |
-| 63,890 | 64.2 s | 995 | 290.6 s | 220 | 4.5× |
+| ~2K | 1.97 s | 996 | 14.64 s | 134 | **7.4×** |
+| ~8K | 7.19 s | 1,095 | 52.38 s | 150 | **7.3×** |
+| ~16K | 10.71 s | 1,483 | 107.57 s | 148 | **10.0×** |
+| ~32K | 28.07 s | 1,136 | 224.57 s | 142 | **8.0×** |
+| ~64K | 77.20 s | 828 | 508.11 s | 126 | **6.6×** |
 
-Both scale roughly **linearly**, not quadratically — the hybrid attention doing its job, since
-only 16 of 64 (dense) / 10 of 40 (MoE) layers keep a real KV cache. But the dense model's
-absolute rate is low enough to hurt: a 32K context costs ~2 minutes before the first token.
+Two readings:
 
-Mitigated in practice by prefix caching — this server's own stats show 1,392,640 cached of
+- **Prefill is where the MoE's lead is widest** — 6.6–10.0×, against 5.7× on decode. (The
+  contaminated data had *understated* this; the corrected data supports the claim the earlier
+  draft made for the wrong reason.)
+- **The dense model's prefill is punishing in absolute terms.** It holds a near-flat
+  126–150 tok/s at every length — linear scaling, which is architecturally good — but the
+  rate is low enough that a 64K context costs **8.5 minutes before the first token**. For
+  repo-scale context that, not decode, is the thing that makes it unusable.
+
+Mitigated in practice by prefix caching: this server's own stats show 1,392,640 cached of
 1,927,616 prompt tokens, a **72% hit rate**. First turn on a big context is expensive;
-follow-ups are not.
+follow-ups are not. (That same cache is what corrupted the first measurement.)
 
 ## Results: speculative decoding
 
-Previously benchmarked here and **rejected**: a Gemma-4 26B-A4B drafter measured 0.97× on
-this machine and 0.91× on an M3 Pro — a net loss, because a ~4B-active MoE isn't
-memory-bandwidth-bound on Apple Silicon so a drafter has nothing to recover.
+Previously benchmarked and **rejected**: a Gemma-4 26B-A4B drafter measured 0.97× here and
+0.91× on an M3 Pro — a net loss, because a ~4B-active MoE is not bandwidth-bound so a drafter
+has nothing to recover.
 
 A dense 27B is the opposite regime, and Qwen3.8 ships MTP heads. Re-tested with oMLX
 `vlm_mtp` + the 239 MB `Qwen3.8-27B-MTP-4bit` drafter:
@@ -187,88 +316,186 @@ A dense 27B is the opposite regime, and Qwen3.8 ships MTP heads. Re-tested with 
 | prose | 23.69 | 25.37 | 1.07× | 50.5% (2.01) |
 | qa | 23.78 | 25.95 | 1.09× | 43.0% (1.86) |
 
-**Then the catch.** Greedy verification is supposed to make this *bit-identical*. Tested
-rather than assumed:
+**Then the catch.** Greedy verification should be bit-identical. Tested rather than assumed:
 
 | run | result |
 |---|---|
-| **control**: drafter OFF, captured twice across a restart | **3/3 identical** |
+| **control** — drafter OFF, captured twice across a restart | **3/3 identical** |
 | drafter OFF vs drafter ON | **1/3 identical — 2 prompts diverged** |
 
-The control is what makes it conclusive: the server *is* deterministic at temperature 0,
-reproducing identical hashes even across a restart. So the divergence is real. **Left
-disabled** — a 1.43× speedup that silently changes output is not the trade the technique
-advertises.
+The control shows the server is deterministic at temperature 0, reproducing identical hashes
+even across a restart — so the divergence is consistent with a real effect of the drafter
+rather than nondeterminism. With n=3 this is strong evidence rather than proof, and it looks
+like an oMLX 0.5.7 bug. **Left disabled** — a 1.43× speedup that silently changes output is
+not the trade the technique advertises.
 
 [mlx-dspark](https://github.com/ARahim3/mlx-dspark) was also evaluated (code 1.55×, math
 1.47×, chat 1.15×). Better *ratios*, but from a ~16 tok/s baseline vs oMLX's ~23, so its
-accelerated 24.9 tok/s still loses to oMLX+MTP's 32.9 — and it means a second server. Not
-adopted.
+accelerated 24.9 tok/s still loses to oMLX+MTP's 32.9 — and it means a second server on port
+8080. **Not adopted.**
+
+## Settings research: what we checked for a free win, and what we found
+
+Before locking this in we went looking for settings or checkpoints that would improve quality
+or speed at no cost. Most candidates did not survive contact with the numbers.
+
+**Sampling parameters — already correct, verified against the official card.** Qwen publishes
+*different* recommendations per task type for Qwen3.6-35B-A3B:
+
+| mode | temp | top_p | top_k | min_p | presence_penalty |
+|---|---|---|---|---|---|
+| Thinking, general | 1.0 | 0.95 | 20 | 0.0 | **1.5** |
+| **Thinking, precise coding** | **0.6** | **0.95** | **20** | **0.0** | **0.0** |
+| Non-thinking / instruct | 0.7 | 0.80 | 20 | 0.0 | 1.5 |
+
+Our shipped config (temp 0.6, presence_penalty 0.0) is exactly the **precise-coding** row —
+no change needed. The card warns that a higher `presence_penalty` "may occasionally result in
+language mixing and a slight decrease in model performance", so the general-purpose 1.5 is
+explicitly *not* what you want for code. We added `min_p: 0.0` explicitly to match. Qwen also
+recommends an output length of 32,768 tokens for most queries and 81,920 for hard
+maths/programming — our pi registry already declares `maxTokens: 81920`.
+
+**DWQ (distilled weight quantization) — real, but not free.** `Qwen3.6-35B-A3B-4bit-DWQ`
+gradient-optimizes the quantization scales against a full-precision teacher, and is reported
+to behave like ~4.6-bit. Measured here: **10/10 on the coding eval (the best result of
+anything tested) but 103.6 tok/s vs 130.7 — a 21% speed cost.** By our own n=10 standard the
+extra task is not a demonstrated quality gain, while the 21% is measured and certain. Kept on
+disk and documented as the quality-leaning alternative; **not made the default.** The slowdown
+has a clear cause: DWQ keeps embeddings, `lm_head`, routers and shared experts at higher
+precision, and in a MoE those are read on *every* token.
+
+**OptiQ — rejected on its own numbers.** `Qwen3.6-35B-A3B-OptiQ-4bit` advertises a higher
+aggregate "Capability Score", but the per-metric table shows it **losing** on MMLU (−0.9),
+GSM8K (−1.5) and IFEval (−0.4), **tying HumanEval (+0.0)**, and winning only on BFCL-V3
+(+2.5) and HashHop (+8.0). The aggregate is carried by long-context retrieval. For coding
+specifically it offers nothing, and it is 24.7 GB against our 19 GB.
+
+**TurboQuant KV-cache quantization — do not enable.** oMLX exposes `turboquant_kv_enabled` /
+`turboquant_kv_bits`, but 4-bit and 6-bit modes are reported ~8× *slower* than off (a known
+regression); only 8-bit improves anything, and the toggle has at times been disabled pending
+a prefill-path fix.
 
 ---
 
-## The part worth blogging: confounds that produced wrong numbers
+## Confounds that produced wrong numbers
 
-Every one of these silently produced a plausible, wrong result.
+Every one of these produced a plausible, wrong result. Three needed permanent tooling.
 
 **1. Foreign traffic on a shared server.** A scheduled digest job (normally 05:30, fired late
-as a launchd wake catch-up) hammered a *different* model on the same inference server for ~5
-minutes. It overlapped exactly one model's window and depressed that measurement ~20% —
-11.7 vs 14.6 tok/s. Nothing in the benchmark output hinted at it. Fix: a script that audits a
-time window against the server log and refuses to certify a run that shared the GPU.
+as a launchd wake catch-up) hammered `gpt-oss-120b` on the same oMLX instance for ~5 minutes.
+It overlapped exactly one model's window — `Qwen3.6-27B-8bit`, which read **11.7 tok/s**
+contaminated versus **11.98 tok/s** in the final clean run. Nothing in the benchmark output
+hinted at it. `bench/contention_audit.sh` now audits a window against the server log, and
+**fails closed**: an unparseable window, an unreadable log, or an empty window is a hard
+error, because a false "CLEAN" launders a bad run as verified.
 
-**2. Engine-pool residency.** oMLX keeps every model it has served resident. With four models
-/ 69 GB loaded and free memory at 38%, Qwen3.8-27B-4bit measured **32% slower** than
-Qwen3.6-27B-4bit — a difference that would have been written up as a real regression. Measured
-alone, they are within 4%, exactly as byte-identical weights predict. Fix: restart the server
-before every model.
+**2. Engine-pool residency.** oMLX keeps every model it has served resident. With 4 models /
+69 GB loaded and free memory at 38%, Qwen3.8-27B-4bit measured **32% slower** than
+Qwen3.6-27B-4bit — which would have been written up as a real regression. Measured alone they
+are within 4.4%, as identically-sized weights on an identical architecture predict. Every
+measured model now gets a freshly restarted server.
 
-**3. Ambient desktop load.** WindowServer and DisplayLink take a real GPU slice. To bound it,
-each pass re-measures its *first* model *last*: drift across the full matrix came out at
-**−3.9%** — an order of magnitude too small to manufacture the 2× quant gap, so the ratios
-stand.
+**3. Prefix caching in the long-context test.** Covered in full under benchmark #3 above: a
+4× longer prompt returning *faster* was the tell. Fixed with per-prompt nonces, shuffled
+order, a warm-up, and an explicit `cached_tokens == 0` assertion.
 
 **4. Chunk counts are not token counts.** The streaming API packs several tokens per SSE
-chunk. Counting chunks produced a nonsensical "7 tok/s decode" against a 22 tok/s end-to-end
-rate. Derive decode from `usage.completion_tokens` and TTFT.
+chunk; counting chunks produced a nonsensical "7 tok/s decode" against a 22 tok/s end-to-end
+rate. The harness now hard-fails instead of falling back.
 
 **5. Unequal thinking budgets masquerading as a quality gap.** The first quality comparison
-gave Qwen3.6-27B 2.9× the token budget of Qwen3.8 (9,251 vs 3,185 tokens/task) purely because
-one model has a `reasoning_effort` knob and the other doesn't. That is an *efficiency*
-comparison; reporting it as a quality one would simply have been wrong.
+gave Qwen3.6-27B far more test-time compute than Qwen3.8 purely because one model has a
+`reasoning_effort` knob and the other does not — 10,521 vs 3,185 tokens/task in the final
+runs, a 3.3× gap. That is an *efficiency* comparison; reporting it as a quality one would
+have been wrong.
 
-**6. Truncation is not failure.** Qwen3.6's `path_normalize` run hit the token cap and still
-passed, because the fenced code block landed before the cutoff. Track `finish_reason`
-separately from pass/fail or you will conflate "ran out of room" with "got it wrong".
+**6. Truncation is not failure.** One run hit the token cap and still passed, because the
+fenced code block landed before the cutoff. Track `finish_reason` separately from pass/fail.
 
 **7. `timeout` does not exist on macOS.** A guard using it silently *skipped* an entire
-benchmark phase rather than running it (`gtimeout` from coreutils is the equivalent).
+benchmark phase rather than running it (`gtimeout`, from coreutils, is the equivalent).
+
+Drift control: each pass re-measures its first model last. Across the full matrix that came
+out at **−3.9%** — an order of magnitude too small to manufacture the 2× quant gap.
 
 ---
 
 ## Outcome / current config
 
-- **Default:** `Qwen3.6-35B-A3B-4bit`, temp 0.6 / top_p 0.95 / top_k 20, 8192-token thinking
-  budget (its only runaway guard — no `reasoning_effort` knob exists in 3.6). Registered in
-  `dot/pi/.pi/agent/models.json.tpl`.
-- **Specialist:** `Qwen3.8-27B-4bit`, temp 1.0 / top_p 0.95 / top_k 20,
-  `reasoning_effort: medium`, 8192-token budget. For hard problems and token-tight work.
+- **Default:** `Qwen3.6-35B-A3B-4bit` — temp 0.6 / top_p 0.95 / top_k 20 / min_p 0.0, with an
+  8192-token thinking budget as its only runaway guard (no `reasoning_effort` knob exists in
+  Qwen3.6).
+- **Specialist:** `Qwen3.8-27B-4bit` — temp 1.0 / top_p 0.95 / top_k 20 / min_p 0.0,
+  `reasoning_effort: medium`, 8192-token budget.
+- **Quality-leaning alternative, on disk, not default:** `Qwen3.6-35B-A3B-4bit-DWQ`
+  (10/10 but 21% slower).
 - Speculative decoding **off** pending the losslessness bug.
-- Deleted: `Qwen3.6-27B-4bit`, `Qwen3.6-27B-8bit`, `Qwen3.8-27B-8bit`, DSpark drafter — ~73 GB.
+- Deleted: `Qwen3.6-27B-4bit`, `Qwen3.6-27B-8bit`, `Qwen3.8-27B-8bit`, DSpark drafter (~73 GB).
+
+Two honest notes on the shipped config: the headline 9/10 was measured at temp **1.0** and
+with a 16k ceiling, whereas we ship temp 0.6 (the official coding recommendation) and an 8192
+thinking budget. The budget is deliberately tighter than the ceiling that produced the score —
+it is a guard against the runaway case, and it reserves room for the answer rather than
+capping total output.
 
 ## Open questions
 
-- **The eval ceilings out.** 9/10 and 8/10 cannot separate these models. A harder suite (or
-  several reps per task, since these are single samples at temperature 1.0) would be needed to
-  test whether Qwen3.8's stronger published scores (SWE-bench Pro 61.7, LiveCodeBench v6 90.3,
-  Terminal-Bench 2.1 73.0) show up on real work.
-- **Is oMLX's `vlm_mtp` divergence a bug?** Worth reporting upstream; re-check after upgrades.
+- **The eval ceilings out.** 10/10, 9/10 and 8/10 cannot separate these models. A harder suite,
+  and several repetitions per task (these are single samples at temperature 1.0), would be
+  needed to test whether Qwen3.8's stronger published scores (SWE-bench Pro 61.7,
+  LiveCodeBench v6 90.3, Terminal-Bench 2.1 73.0) show up on real work.
+- **Is oMLX's `vlm_mtp` divergence a bug?** Worth reporting upstream; re-check after upgrades
+  with `bench/lossless_check.py`.
+- **DWQ deserves a proper test** — a bigger suite would say whether that 10/10 is real.
 - **Vision untested.** Both models are VLMs; only text was ever sent.
+
+## Reproduction
+
+The harness is checked in at **`dot/omlx/bench/`**. It reads the oMLX API key from
+`$OMLX_API_KEY`, or from a gitignored `omlx_key` file beside the scripts.
+
+```bash
+cd ~/Git/toolbox/dot/omlx/bench
+export OMLX_API_KEY=$(python3 -c "import json,os;print(json.load(
+  open(os.path.expanduser('~/.omlx/settings.json')))['auth']['api_key'])")
+
+# 1. decode/prefill throughput -- 3 reps, code/prose/qa, median per family
+python3 bench.py Qwen3.6-35B-A3B-4bit --reps 3 --out out.json
+
+# 2. reasoning_effort cost per level (Qwen3.8 only; 3.6 has no such knob)
+python3 effort.py Qwen3.8-27B-4bit
+
+# 3. long-context prefill -- nonce'd + shuffled so the prefix cache cannot help
+python3 longctx.py Qwen3.6-35B-A3B-4bit
+
+# 4. coding eval: 10 original tasks with executable tests.
+#    These exact flags reproduce the headline numbers.
+python3 codeeval.py Qwen3.6-35B-A3B-4bit --max-tokens 16000 --temperature 1.0 \
+    --extra '{"top_p":0.95,"top_k":20}' --reps 1 --out eval.json
+#    Qwen3.8 additionally needs its effort pinned, or it will not terminate:
+python3 codeeval.py Qwen3.8-27B-4bit --max-tokens 16000 --temperature 1.0 \
+    --extra '{"top_p":0.95,"top_k":20,"chat_template_kwargs":{"reasoning_effort":"medium"}}'
+
+# 5. losslessness: capture off, enable the drafter, capture, compare -- and run the
+#    off-vs-off control, without which a divergence is uninterpretable
+python3 lossless_check.py Qwen3.8-27B-4bit off
+#    ...enable vlm_mtp in model_settings.json, restart oMLX...
+python3 lossless_check.py Qwen3.8-27B-4bit on
+python3 lossless_check.py --compare off on
+
+# 6. certify a window had no foreign traffic (fails closed)
+./contention_audit.sh window.txt Qwen3.6-35B-A3B-4bit
+```
+
+**Measure one model per oMLX restart**, stamp the window *after* the restart, and always run
+`contention_audit.sh` afterwards. A model measured alongside 69 GB of other resident models
+reads ~30% slow.
 
 ## Links
 
-- [Qwen3.8-27B model card](https://huggingface.co/Qwen/Qwen3.8-27B) · [mlx 4-bit](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit) · [MTP drafter](https://huggingface.co/mlx-community/Qwen3.8-27B-MTP-4bit)
-- [Qwen3.6-35B-A3B mlx 4-bit](https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit)
+- [Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B) · [mlx 4-bit](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit) · [MTP drafter](https://huggingface.co/mlx-community/Qwen3.8-27B-MTP-4bit)
+- [Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) · [mlx 4-bit](https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit) · [4-bit DWQ](https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit-DWQ) · [OptiQ 4-bit](https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit)
+- [mlx-lm learned quants (DWQ)](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/LEARNED_QUANTS.md)
 - [mlx-dspark](https://github.com/ARahim3/mlx-dspark) · [DSpark drafter](https://huggingface.co/RadixArk/Qwen3.8-27B-DSpark)
 - [Quesma: do Qwen3.6 27B quantizations break the pelican?](https://quesma.com/blog/qwen-quantization-quality/)
 - [Speculative decoding (Leviathan et al., ICML 2023)](https://arxiv.org/abs/2211.17192)

--- a/docs/local-llm-benchmarks.md
+++ b/docs/local-llm-benchmarks.md
@@ -1,0 +1,274 @@
+# Local LLM model selection — measured on moria
+
+Controlled benchmarks of the local coding models we serve through oMLX, run 2026-08-15 when
+Qwen3.8-27B dropped. Covers dense vs MoE, quantization, `reasoning_effort`, speculative
+decoding, and long-context prefill.
+
+**This doc is why `dot/omlx/.omlx/model_settings.json` looks the way it does.** The
+reproducible harness lives in `dot/omlx/bench/`; the earlier MoE-only speculative-decoding
+work is in `dot/omlx/speculative-decoding-findings.md`.
+
+---
+
+## Executive summary
+
+1. **The MoE won. `Qwen3.6-35B-A3B-4bit` is the default coding model** — 130.7 tok/s decode
+   vs the dense `Qwen3.8-27B-4bit`'s 23.0 (**5.7×**), and it scored **9/10 vs 8/10** on an
+   executable coding eval. Faster *and* not worse, so there is no trade to agonise over.
+2. **The newer, higher-benchmarked dense model is the slow specialist.** Qwen3.8-27B is a
+   newer generation with better published scores, but we could not measure a quality
+   advantage — our eval hits a ceiling. Its real edge is **token efficiency**: it solved the
+   eval with 31.8k tokens vs A3B's 84.1k (2.6× fewer).
+3. **On a *dense* model, 8-bit costs ~2× the speed for nothing.** 23.0 → 11.9 tok/s. On a
+   *MoE* it costs only 1.50× (130.7 → 86.9), because a MoE only reads its ~3B active params.
+   The "I have 128 GB so take the 8-bit" instinct is wrong on both, and *most* wrong on dense.
+   No 6-bit exists for these models.
+4. **Qwen3.8-27B is a retrain on the identical Qwen3.6-27B skeleton** — same config,
+   byte-identical 14.95 GiB weights, same measured speed. Free upgrade, old one deleted.
+5. **Qwen3.8's `reasoning_effort` defaults to `xhigh`, which is unusable.** Unconfigured it
+   burned 8,000 tokens over 401 s and *never produced an answer*. Worse, **more thinking made
+   it worse**: `medium` scored 8/10 in 27 min; `xhigh` scored 6/10 in 111 min.
+6. **Speculative decoding finally pays off on a dense model (1.43× on code) — but oMLX's
+   implementation is not bit-identical**, verified against a determinism control. Left off.
+7. **Prefill, not decode, is what you wait for** — and it is where the MoE's lead is widest:
+   a 64K context costs A3B 64 s versus the dense model's 291 s.
+
+**Practical rule:** default to A3B-4bit. Reach for Qwen3.8-27B-4bit only when A3B has
+actually failed a specific hard problem, or when output tokens are precious. Expect to wait
+~5.7× longer when you do.
+
+---
+
+## Test machine
+
+| | |
+|---|---|
+| Machine | MacBook Pro (Mac16,6), "moria" |
+| Chip | Apple M4 Max |
+| CPU | 16 cores (12 performance + 4 efficiency) |
+| GPU | 40 cores |
+| Memory | 128 GB unified |
+| OS | macOS 26.5.2 (25F84) |
+| Server | oMLX 0.5.7 |
+| Runtime | mlx 0.32.0, mlx-vlm 0.6.3, mlx-lm 0.31.3 |
+
+**This is a live desktop, not a clean bench.** WindowServer (~23–30% CPU) and DisplayLink
+(~8%) compete for the GPU. The same model+quant measured 29 tok/s early and 24 tok/s an hour
+later. Absolute numbers carry roughly ±20%; only ratios measured within a single pass are
+trustworthy. Do not compare these numbers across sessions or against other machines.
+
+## Test parameters
+
+| test | parameters |
+|---|---|
+| **Throughput** | temperature 0 (greedy), 200 completion tokens, 3 reps, **median** reported. Three prompt families: code (458 prompt tok), prose (182), qa (179). `decode = completion_tokens / (wall − TTFT)` |
+| **Coding eval** | 10 original tasks (written fresh, not HumanEval/MBPP) each with a hidden executable test suite; pass = every assertion holds. temp 1.0 / top_p 0.95 / top_k 20, `max_tokens` 16000, 1 rep per task |
+| **Long-context** | thinking disabled, output capped at 24 tokens so wall ≈ prefill. Synthetic source-like prompt repeated to length |
+| **reasoning_effort** | one fixed debugging question, temp 1.0 / top_p 0.95 / top_k 20, `max_tokens` 8000 |
+| **Speculative decoding** | matched A/B on one server instance, temp 0, 200 tokens, 3 reps |
+| **Losslessness** | temp 0, 3 fixed prompts, SHA-256 of `reasoning_content` + `content`, drafter off vs on, **plus a control** (off vs off across a restart) |
+
+**Protocol.** oMLX is restarted before *every* measured model so exactly one is resident, and
+each window is audited against the server log for foreign traffic. Both of those controls
+exist because skipping them produced wrong numbers — see the confounds section.
+
+---
+
+## Results: throughput
+
+Decode is the sustained generation rate; TTFT is time-to-first-token on the 458-token code
+prompt.
+
+| model | type | active params | quant | on disk | **decode tok/s** | TTFT |
+|---|---|---|---|---|---|---|
+| **Qwen3.6-35B-A3B-4bit** | MoE | ~3B | 4-bit | 19 GB | **130.73** | 0.50 s |
+| Qwen3.6-35B-A3B-8bit | MoE | ~3B | 8-bit | 35 GB | 86.91 | 0.54 s |
+| Qwen3.6-27B-4bit | dense | 27B | 4-bit | 14.95 GiB | 24.01 | 2.51 s |
+| **Qwen3.8-27B-4bit** | dense | 27B | 4-bit | 14.95 GiB | **22.96** | 2.58 s |
+| Qwen3.6-27B-8bit | dense | 27B | 8-bit | 27.48 GiB | 11.98 | 2.78 s |
+| Qwen3.8-27B-8bit | dense | 27B | 8-bit | 27.48 GiB | 11.93 | 2.34 s |
+
+Per-family medians for the two finalists:
+
+| model | code | prose | qa | avg |
+|---|---|---|---|---|
+| Qwen3.6-35B-A3B-4bit | 132.61 | 130.66 | 128.92 | **130.73** |
+| Qwen3.8-27B-4bit | 23.86 | 22.91 | 22.11 | **22.96** |
+
+**Quantization cost, by architecture:**
+
+| architecture | 4-bit | 8-bit | penalty |
+|---|---|---|---|
+| dense 27B (Qwen3.8) | 22.96 | 11.93 | **1.92×** |
+| dense 27B (Qwen3.6) | 24.01 | 11.98 | **2.00×** |
+| MoE 35B-A3B (Qwen3.6) | 130.73 | 86.91 | **1.50×** |
+
+A dense model re-reads every parameter each decode step, so time tracks weight bytes (ratio
+27.48/14.95 = 1.84; the excess is KV-cache and activation traffic that doesn't shrink). A MoE
+reads only its active experts, so 8-bit hurts less — but it still is not free, which is the
+part people get wrong.
+
+## Results: coding eval
+
+10 original tasks, executable tests. Four of the ten suites were validated against reference
+solutions first, so a failure means the model got it wrong, not that the harness is broken.
+
+| model | config | **pass** | truncated | tokens | wall-clock | effective tok/s |
+|---|---|---|---|---|---|---|
+| **Qwen3.6-35B-A3B-4bit** | temp 1.0 | **9/10** | 1 | 84,062 | **17.4 min** | 80.6 |
+| Qwen3.8-27B-4bit | `reasoning_effort: medium` | 8/10 | 1 | 31,849 | 27.1 min | 19.6 |
+| Qwen3.6-27B-4bit | default (no effort knob) | 8/10 | 3 | 105,207 | 90.7 min | 19.3 |
+| Qwen3.8-27B-4bit | `reasoning_effort: xhigh` | 6/10 | 4 | 123,418 | 111.5 min | 18.4 |
+
+Each model is shown at the best configuration found for it. The MoE finishes the whole suite
+in 17 minutes; the dense model's best run takes 27, and its *maximum-effort* run takes 111
+minutes to score two points lower.
+
+**Read the quality column carefully.** 9-vs-8 on ten tasks is one task — that is noise, not a
+demonstrated quality difference, and both are near the ceiling of this eval, which is exactly
+when a benchmark stops discriminating. The honest claim is *"the MoE was not worse"*, not
+*"the MoE is better"*. The **5.7× speed difference is not noise.**
+
+The 8-vs-6 gap between `medium` and `xhigh` **on the same model and same tasks** is much
+better founded, because the failure mode is mechanical and identifiable (truncation).
+
+## Results: `reasoning_effort` (Qwen3.8 only — new in 3.8, absent in 3.6)
+
+The chat template defaults it to `xhigh` (`chat_template.jinja:47`). One debugging question,
+8000-token cap:
+
+| reasoning_effort | tokens | wall | think / answer chars | finish |
+|---|---|---|---|---|
+| *(unset → xhigh)* | 8000 (cap) | 401 s | 0 / 36,487 | `length` — **no answer** |
+| `low` | 1,925 | 95 s | 5,940 / 2,119 | clean stop |
+| `medium` | 3,589 | 178 s | 10,371 / 3,938 | clean stop |
+| `xhigh` (explicit) | 8000 (cap) | 405 s | 0 / 35,896 | `length` — **no answer** |
+| `enable_thinking: false` | 848 | 42 s | 0 / 3,444 | clean stop |
+
+Unset and explicit `xhigh` behave identically, confirming the default. A side effect worth
+knowing: because `</think>` never arrives, the parser cannot split reasoning from content, so
+all ~36k characters land in `content` and `reasoning_content` comes back empty.
+
+Practical ordering on this hardware: **`medium` > `low` ≫ `xhigh` (the shipped default)**.
+
+## Results: long-context prefill
+
+For an agent, felt latency is usually prefill — you send a big context and wait. Decode tok/s
+says nothing about it. This is where the MoE's advantage is widest.
+
+| prompt tokens | A3B-4bit wall | A3B tok/s | Qwen3.8-27B-4bit wall | dense tok/s | **speedup** |
+|---|---|---|---|---|---|
+| 1,946 | 7.1 s | 273 | 15.5 s | 125 | 2.2× |
+| 7,862 | 5.4 s | 1,451 | 48.8 s | 161 | 9.0× |
+| 15,866 | 10.4 s | 1,532 | 63.5 s | 250 | 6.1× |
+| 31,874 | 24.2 s | 1,320 | 127.7 s | 250 | 5.3× |
+| 63,890 | 64.2 s | 995 | 290.6 s | 220 | 4.5× |
+
+Both scale roughly **linearly**, not quadratically — the hybrid attention doing its job, since
+only 16 of 64 (dense) / 10 of 40 (MoE) layers keep a real KV cache. But the dense model's
+absolute rate is low enough to hurt: a 32K context costs ~2 minutes before the first token.
+
+Mitigated in practice by prefix caching — this server's own stats show 1,392,640 cached of
+1,927,616 prompt tokens, a **72% hit rate**. First turn on a big context is expensive;
+follow-ups are not.
+
+## Results: speculative decoding
+
+Previously benchmarked here and **rejected**: a Gemma-4 26B-A4B drafter measured 0.97× on
+this machine and 0.91× on an M3 Pro — a net loss, because a ~4B-active MoE isn't
+memory-bandwidth-bound on Apple Silicon so a drafter has nothing to recover.
+
+A dense 27B is the opposite regime, and Qwen3.8 ships MTP heads. Re-tested with oMLX
+`vlm_mtp` + the 239 MB `Qwen3.8-27B-MTP-4bit` drafter:
+
+| prompt | drafter OFF | drafter ON | speedup | acceptance |
+|---|---|---|---|---|
+| code | 23.05 | **32.91** | **1.43×** | 63.6% (2.27 tok/round) |
+| prose | 23.69 | 25.37 | 1.07× | 50.5% (2.01) |
+| qa | 23.78 | 25.95 | 1.09× | 43.0% (1.86) |
+
+**Then the catch.** Greedy verification is supposed to make this *bit-identical*. Tested
+rather than assumed:
+
+| run | result |
+|---|---|
+| **control**: drafter OFF, captured twice across a restart | **3/3 identical** |
+| drafter OFF vs drafter ON | **1/3 identical — 2 prompts diverged** |
+
+The control is what makes it conclusive: the server *is* deterministic at temperature 0,
+reproducing identical hashes even across a restart. So the divergence is real. **Left
+disabled** — a 1.43× speedup that silently changes output is not the trade the technique
+advertises.
+
+[mlx-dspark](https://github.com/ARahim3/mlx-dspark) was also evaluated (code 1.55×, math
+1.47×, chat 1.15×). Better *ratios*, but from a ~16 tok/s baseline vs oMLX's ~23, so its
+accelerated 24.9 tok/s still loses to oMLX+MTP's 32.9 — and it means a second server. Not
+adopted.
+
+---
+
+## The part worth blogging: confounds that produced wrong numbers
+
+Every one of these silently produced a plausible, wrong result.
+
+**1. Foreign traffic on a shared server.** A scheduled digest job (normally 05:30, fired late
+as a launchd wake catch-up) hammered a *different* model on the same inference server for ~5
+minutes. It overlapped exactly one model's window and depressed that measurement ~20% —
+11.7 vs 14.6 tok/s. Nothing in the benchmark output hinted at it. Fix: a script that audits a
+time window against the server log and refuses to certify a run that shared the GPU.
+
+**2. Engine-pool residency.** oMLX keeps every model it has served resident. With four models
+/ 69 GB loaded and free memory at 38%, Qwen3.8-27B-4bit measured **32% slower** than
+Qwen3.6-27B-4bit — a difference that would have been written up as a real regression. Measured
+alone, they are within 4%, exactly as byte-identical weights predict. Fix: restart the server
+before every model.
+
+**3. Ambient desktop load.** WindowServer and DisplayLink take a real GPU slice. To bound it,
+each pass re-measures its *first* model *last*: drift across the full matrix came out at
+**−3.9%** — an order of magnitude too small to manufacture the 2× quant gap, so the ratios
+stand.
+
+**4. Chunk counts are not token counts.** The streaming API packs several tokens per SSE
+chunk. Counting chunks produced a nonsensical "7 tok/s decode" against a 22 tok/s end-to-end
+rate. Derive decode from `usage.completion_tokens` and TTFT.
+
+**5. Unequal thinking budgets masquerading as a quality gap.** The first quality comparison
+gave Qwen3.6-27B 2.9× the token budget of Qwen3.8 (9,251 vs 3,185 tokens/task) purely because
+one model has a `reasoning_effort` knob and the other doesn't. That is an *efficiency*
+comparison; reporting it as a quality one would simply have been wrong.
+
+**6. Truncation is not failure.** Qwen3.6's `path_normalize` run hit the token cap and still
+passed, because the fenced code block landed before the cutoff. Track `finish_reason`
+separately from pass/fail or you will conflate "ran out of room" with "got it wrong".
+
+**7. `timeout` does not exist on macOS.** A guard using it silently *skipped* an entire
+benchmark phase rather than running it (`gtimeout` from coreutils is the equivalent).
+
+---
+
+## Outcome / current config
+
+- **Default:** `Qwen3.6-35B-A3B-4bit`, temp 0.6 / top_p 0.95 / top_k 20, 8192-token thinking
+  budget (its only runaway guard — no `reasoning_effort` knob exists in 3.6). Registered in
+  `dot/pi/.pi/agent/models.json.tpl`.
+- **Specialist:** `Qwen3.8-27B-4bit`, temp 1.0 / top_p 0.95 / top_k 20,
+  `reasoning_effort: medium`, 8192-token budget. For hard problems and token-tight work.
+- Speculative decoding **off** pending the losslessness bug.
+- Deleted: `Qwen3.6-27B-4bit`, `Qwen3.6-27B-8bit`, `Qwen3.8-27B-8bit`, DSpark drafter — ~73 GB.
+
+## Open questions
+
+- **The eval ceilings out.** 9/10 and 8/10 cannot separate these models. A harder suite (or
+  several reps per task, since these are single samples at temperature 1.0) would be needed to
+  test whether Qwen3.8's stronger published scores (SWE-bench Pro 61.7, LiveCodeBench v6 90.3,
+  Terminal-Bench 2.1 73.0) show up on real work.
+- **Is oMLX's `vlm_mtp` divergence a bug?** Worth reporting upstream; re-check after upgrades.
+- **Vision untested.** Both models are VLMs; only text was ever sent.
+
+## Links
+
+- [Qwen3.8-27B model card](https://huggingface.co/Qwen/Qwen3.8-27B) · [mlx 4-bit](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit) · [MTP drafter](https://huggingface.co/mlx-community/Qwen3.8-27B-MTP-4bit)
+- [Qwen3.6-35B-A3B mlx 4-bit](https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit)
+- [mlx-dspark](https://github.com/ARahim3/mlx-dspark) · [DSpark drafter](https://huggingface.co/RadixArk/Qwen3.8-27B-DSpark)
+- [Quesma: do Qwen3.6 27B quantizations break the pelican?](https://quesma.com/blog/qwen-quantization-quality/)
+- [Speculative decoding (Leviathan et al., ICML 2023)](https://arxiv.org/abs/2211.17192)

--- a/dot/omlx/.gitignore
+++ b/dot/omlx/.gitignore
@@ -1,3 +1,8 @@
 .omlx/models/
 .omlx/cache/
 .omlx/logs/
+# Harness runtime: the oMLX API key is read from bench/omlx_key at runtime.
+# It must never be committed - all other secrets go through 1Password/op inject.
+bench/omlx_key
+# Result files written into the harness dir by effort.py / longctx.py / lossless_check.py
+bench/*.json

--- a/dot/omlx/.omlx/model_settings.json
+++ b/dot/omlx/.omlx/model_settings.json
@@ -3,16 +3,27 @@
   "_comment": "Per-model overrides. These take precedence over sampling defaults in settings.json.",
   "models": {
     "Qwen3.6-35B-A3B-4bit": {
-      "description": "DEFAULT local coding model (MoE, 35B total / ~3B active, 4-bit, ~19GB). Measured on moria: 130.7 t/s decode and 995-1532 t/s prefill -- 5.7x the decode and ~5x the prefill of the dense Qwen3.8-27B-4bit -- while scoring 9/10 vs 8/10 on our 10-task executable coding eval. It is faster AND was not worse, so it is the default. 4-bit over 8-bit: the 8-bit sibling measured 86.9 t/s, a 1.50x penalty (cheaper than the dense model's 1.92-2.00x, because a MoE only reads its ~3B active params, but still not free). Full write-up: docs/local-llm-benchmarks.md.",
+      "description": "DEFAULT local coding model (MoE, 35B total / ~3B active, 4-bit, ~19GB). Measured on moria: 130.7 t/s decode vs the dense Qwen3.8-27B-4bit's 23.0 (5.7x), and 6.6-10.0x faster prefill, while scoring 9/10 vs 8/10 on our 10-task executable coding eval. Faster AND not worse, so it is the default. 4-bit over 8-bit: the 8-bit sibling measured 86.9 t/s, a 1.50x penalty -- cheaper than the dense model's 1.92-2.00x because a MoE only reads its ~3B active params, but NOT free. Full write-up: docs/local-llm-benchmarks.md.",
       "temperature": 0.6,
       "top_p": 0.95,
       "top_k": 20,
       "repetition_penalty": 1.0,
       "presence_penalty": 0.0,
-
-      "_comment_sampling": "temp 0.6 matches the Unsloth recommendation for Qwen3.6 and our existing -8bit entry. NOTE our coding eval ran this model at temp 1.0 (to match the knobs the dense model was measured with) and scored 9/10, so both settings work; 0.6 is shipped for consistency with the rest of the Qwen3.6 family.",
-
+      "_comment_sampling": "These are Qwen's OFFICIAL 'thinking, precise coding' parameters for this model (temp 0.6 / top_p 0.95 / top_k 20 / min_p 0.0 / presence_penalty 0.0). Qwen publishes a DIFFERENT set for general thinking work (temp 1.0, presence_penalty 1.5) -- do not copy that one here; the card warns a higher presence_penalty 'may occasionally result in language mixing and a slight decrease in model performance'. NOTE our coding eval ran this model at temp 1.0 (to match the knobs the dense model was measured with) and scored 9/10, so the headline number was not produced by the shipped temperature.",
       "_comment_thinking": "Same runaway guard as the -8bit entry. This model has no reasoning_effort knob (that is new in Qwen3.8), so the token budget is the ONLY bound available. It spent ~8.4k tokens/task on our eval and truncated one task at 16k.",
+      "thinking_budget_enabled": true,
+      "thinking_budget_tokens": 8192,
+      "min_p": 0.0,
+      "_comment_alternatives": "Considered and rejected: Qwen3.6-35B-A3B-OptiQ-4bit advertises a higher aggregate Capability Score but per-metric it LOSES on MMLU (-0.9), GSM8K (-1.5) and IFEval (-0.4), TIES HumanEval (+0.0), and wins only on BFCL-V3 and HashHop -- nothing for coding, at 24.7GB vs 19GB. TurboQuant KV (turboquant_kv_*) is a known ~8x slowdown at 4/6-bit. See the -DWQ entry for the one alternative that is genuinely competitive."
+    },
+    "Qwen3.6-35B-A3B-4bit-DWQ": {
+      "description": "QUALITY-LEANING ALTERNATIVE to Qwen3.6-35B-A3B-4bit, NOT the default. DWQ (distilled weight quantization) gradient-optimizes the quant scales against a full-precision teacher and is reported to behave like ~4.6-bit. Measured on moria: 10/10 on our coding eval -- the best result of anything tested, and the only model to pass diff_lcs -- but 103.6 t/s vs 130.7, a 21% speed cost. By our own n=10 standard that extra task is NOT a demonstrated quality gain while the 21% is measured and certain, so the plain 4-bit stays default. The slowdown has a clear cause: DWQ keeps embeddings, lm_head, routers and shared experts at higher precision, and a MoE reads those on every token. Swap it in if a harder eval ever justifies it.",
+      "temperature": 0.6,
+      "top_p": 0.95,
+      "top_k": 20,
+      "min_p": 0.0,
+      "repetition_penalty": 1.0,
+      "presence_penalty": 0.0,
       "thinking_budget_enabled": true,
       "thinking_budget_tokens": 8192
     },
@@ -23,41 +34,39 @@
       "top_k": 20,
       "repetition_penalty": 1.0,
       "presence_penalty": 0.0,
-
-      "_comment_reasoning_effort": "THE most important setting for this model. Qwen3.8's chat template adds reasoning_effort and DEFAULTS IT TO xhigh (chat_template.jinja:47). Measured on moria: xhigh burns the entire 8000-token budget over 401s and never emits an answer (finish_reason=length). On our 10-task coding eval, medium scored 8/10 using 31.8k tokens while xhigh scored 6/10 using 123.4k -- every extra failure was a truncation. More thinking is strictly worse here. medium is the default; pass reasoning_effort per-request to override.",
-      "chat_template_kwargs": { "reasoning_effort": "medium" },
-
+      "_comment_reasoning_effort": "THE most important setting for this model. Qwen3.8's chat template adds reasoning_effort and DEFAULTS IT TO xhigh (chat_template.jinja:47). Measured on moria: xhigh burns the entire 8000-token budget over 401s and never emits an answer (finish_reason=length). On our 10-task coding eval, medium scored 8/10 using 31.8k tokens while xhigh scored 6/10 using 123.4k -- every extra failure was a truncation. The unambiguous result is that unset/xhigh NEVER TERMINATES (401s, finish_reason=length, no answer at all); the 8-vs-6 eval gap is two tasks and is suggestive rather than proven. medium is the default; pass reasoning_effort per-request to override.",
+      "chat_template_kwargs": {
+        "reasoning_effort": "medium"
+      },
       "_comment_thinking_budget": "Hard stop, belt-and-braces with reasoning_effort. Even at medium one task ran to a 16k cap. reasoning_effort shapes intent; this bounds it.",
       "thinking_budget_enabled": true,
       "thinking_budget_tokens": 8192,
-
-      "_comment_no_speculative_decoding": "vlm_mtp with Qwen3.8-27B-MTP-4bit IS a real speedup here (1.43x on code, 1.19x avg) -- unlike our gemma MoE result -- because a dense 27B is genuinely bandwidth-bound. It is NOT enabled because we measured it is NOT lossless: with a verified determinism control (drafter off, same prompts, 3/3 identical across a restart), turning the drafter ON changed output on 2 of 3 prompts. Greedy verification is supposed to be bit-identical, so this looks like an oMLX 0.5.7 bug. Re-check with dot/omlx/bench/lossless_check.py after any oMLX upgrade."
+      "_comment_no_speculative_decoding": "vlm_mtp with Qwen3.8-27B-MTP-4bit IS a real speedup here (1.43x on code, 1.19x avg) -- unlike our gemma MoE result -- because a dense 27B is genuinely bandwidth-bound. It is NOT enabled because we measured it is NOT lossless: with a verified determinism control (drafter off, same prompts, 3/3 identical across a restart), turning the drafter ON changed output on 2 of 3 prompts. Greedy verification is supposed to be bit-identical, so this looks like an oMLX 0.5.7 bug (n=3, so strong evidence rather than proof). Re-check with dot/omlx/bench/lossless_check.py after any oMLX upgrade.",
+      "min_p": 0.0
     },
     "Qwen3.6-35B-A3B-8bit": {
-      "description": "SUPERSEDED by Qwen3.6-35B-A3B-4bit for general use -- measured 86.9 t/s here vs 130.7 t/s at 4-bit (a 1.50x penalty) for 35GB instead of 19GB. Kept because it is the target of the nix-managed -long-context symlink and as an 8-bit reference point. Unsloth-recommended sampling for Qwen3.6 coding/agentic tasks. Source: https://unsloth.ai/docs/models/qwen3.6 — also validated by multiple r/LocalLLaMA threads (see llm.md notes).",
+      "description": "SUPERSEDED by Qwen3.6-35B-A3B-4bit for general use -- measured 86.9 t/s here vs 130.7 t/s at 4-bit (a 1.50x penalty) for 35GB instead of 19GB. Kept because it is the target of the nix-managed -long-context symlink and as an 8-bit reference point. Unsloth-recommended sampling for Qwen3.6 coding/agentic tasks. Source: https://unsloth.ai/docs/models/qwen3.6 \u2014 also validated by multiple r/LocalLLaMA threads (see llm.md notes).",
       "temperature": 0.6,
       "top_p": 0.95,
       "top_k": 20,
       "repetition_penalty": 1.0,
       "presence_penalty": 0.0,
-
-      "_comment_thinking": "Cap thinking tokens to prevent infinite reasoning loops. Qwen3.6-35B-A3B is prone to these — see https://www.reddit.com/r/LocalLLaMA/comments/1spdvpo/ and https://itayinbarr.substack.com/p/honey-i-shrunk-the-coding-agent (little-coder used 2048; we use 8192 for more headroom on complex tasks).",
+      "_comment_thinking": "Cap thinking tokens to prevent infinite reasoning loops. Qwen3.6-35B-A3B is prone to these \u2014 see https://www.reddit.com/r/LocalLLaMA/comments/1spdvpo/ and https://itayinbarr.substack.com/p/honey-i-shrunk-the-coding-agent (little-coder used 2048; we use 8192 for more headroom on complex tasks).",
       "thinking_budget_enabled": true,
       "thinking_budget_tokens": 8192
     },
     "gemma-4-26b-a4b-it-qat-4bit": {
-      "description": "Canonical gemma — QAT (quantization-aware-trained) 4-bit. Same ~15GB footprint and decode speed as a naive post-training 4-bit quant, better quality at low bit-width (Google simulates quantization during training to minimize error). Tuned for summarization/RAG: low temp reduces hallucination, thinking disabled (wasted compute for non-reasoning tasks). Sources: mlx-community/gemma-4-26B-A4B-it-qat-4bit, https://blog.google/innovation-and-ai/technology/developers-tools/quantization-aware-training-gemma-4/.",
+      "description": "Canonical gemma \u2014 QAT (quantization-aware-trained) 4-bit. Same ~15GB footprint and decode speed as a naive post-training 4-bit quant, better quality at low bit-width (Google simulates quantization during training to minimize error). Tuned for summarization/RAG: low temp reduces hallucination, thinking disabled (wasted compute for non-reasoning tasks). Sources: mlx-community/gemma-4-26B-A4B-it-qat-4bit, https://blog.google/innovation-and-ai/technology/developers-tools/quantization-aware-training-gemma-4/.",
       "temperature": 0.3,
       "top_p": 0.95,
       "top_k": 64,
       "repetition_penalty": 1.0,
       "presence_penalty": 0.0,
       "thinking_budget_enabled": false,
-
-      "_comment_no_speculative_decoding": "DO NOT add a vlm_mtp / dflash / mtp drafter to this model. We tested the Gemma 4 assistant-MTP drafter on moria (M4 Max) and dungeon (M3 Pro): net 0.97x and 0.91x respectively — a measured LOSS on both. A low-active-param MoE (A4B activates ~4B/token) on Apple Silicon isn't bandwidth-bound, so speculative decoding has nothing to recover and the drafter overhead dominates. Full write-up + reproduction: dot/omlx/speculative-decoding-findings.md."
+      "_comment_no_speculative_decoding": "DO NOT add a vlm_mtp / dflash / mtp drafter to this model. We tested the Gemma 4 assistant-MTP drafter on moria (M4 Max) and dungeon (M3 Pro): net 0.97x and 0.91x respectively \u2014 a measured LOSS on both. A low-active-param MoE (A4B activates ~4B/token) on Apple Silicon isn't bandwidth-bound, so speculative decoding has nothing to recover and the drafter overhead dominates. Full write-up + reproduction: dot/omlx/speculative-decoding-findings.md."
     },
     "gemma-4-e4b-it-qat-4bit": {
-      "description": "Lighter Gemma 4 E4B (~4.5B effective / 8B total params, QAT 4-bit, ~5-6GB) for fast batch summarisation/indexing (roger vault index). Same tuning philosophy as the 26B-A4B — low temp to reduce hallucination, thinking disabled (non-reasoning task) — but a far smaller footprint/load time, chosen to speed up re-summarising the whole vault. Source: mlx-community/gemma-4-E4B-it-qat-4bit.",
+      "description": "Lighter Gemma 4 E4B (~4.5B effective / 8B total params, QAT 4-bit, ~5-6GB) for fast batch summarisation/indexing (roger vault index). Same tuning philosophy as the 26B-A4B \u2014 low temp to reduce hallucination, thinking disabled (non-reasoning task) \u2014 but a far smaller footprint/load time, chosen to speed up re-summarising the whole vault. Source: mlx-community/gemma-4-E4B-it-qat-4bit.",
       "temperature": 0.3,
       "top_p": 0.95,
       "top_k": 64,

--- a/dot/omlx/.omlx/model_settings.json
+++ b/dot/omlx/.omlx/model_settings.json
@@ -2,8 +2,39 @@
   "version": 1,
   "_comment": "Per-model overrides. These take precedence over sampling defaults in settings.json.",
   "models": {
+    "Qwen3.6-35B-A3B-4bit": {
+      "description": "DEFAULT local coding model (MoE, 35B total / ~3B active, 4-bit, ~19GB). Measured on moria: 130.7 t/s decode and 995-1532 t/s prefill -- 5.7x the decode and ~5x the prefill of the dense Qwen3.8-27B-4bit -- while scoring 9/10 vs 8/10 on our 10-task executable coding eval. It is faster AND was not worse, so it is the default. 4-bit over 8-bit: the 8-bit sibling measured 86.9 t/s, a 1.50x penalty (cheaper than the dense model's 1.92-2.00x, because a MoE only reads its ~3B active params, but still not free). Full write-up: docs/local-llm-benchmarks.md.",
+      "temperature": 0.6,
+      "top_p": 0.95,
+      "top_k": 20,
+      "repetition_penalty": 1.0,
+      "presence_penalty": 0.0,
+
+      "_comment_sampling": "temp 0.6 matches the Unsloth recommendation for Qwen3.6 and our existing -8bit entry. NOTE our coding eval ran this model at temp 1.0 (to match the knobs the dense model was measured with) and scored 9/10, so both settings work; 0.6 is shipped for consistency with the rest of the Qwen3.6 family.",
+
+      "_comment_thinking": "Same runaway guard as the -8bit entry. This model has no reasoning_effort knob (that is new in Qwen3.8), so the token budget is the ONLY bound available. It spent ~8.4k tokens/task on our eval and truncated one task at 16k.",
+      "thinking_budget_enabled": true,
+      "thinking_budget_tokens": 8192
+    },
+    "Qwen3.8-27B-4bit": {
+      "description": "SPECIALIST, not the default (dense 27B, 4-bit, 14.95GiB). Reach for it when A3B-4bit has actually failed a specific hard problem, or when output tokens are precious -- it solved our eval with 31.8k tokens vs A3B's 84.1k (2.6x fewer). Otherwise A3B-4bit is 5.7x faster and scored a point higher. IMPORTANT: we did NOT measure a quality advantage for this model; our 10-task eval hits a ceiling (8/10 vs 9/10) and cannot discriminate. Its case rests on published benchmarks (SWE-bench Pro 61.7, LiveCodeBench v6 90.3, Terminal-Bench 2.1 73.0) being a newer generation, not on our data. 4-bit not 8-bit: on a DENSE 27B the 8-bit quant measured ~2x slower (23.0 -> 11.9 t/s) for a quality difference nobody can detect at >=4 bits. No 6-bit exists upstream. Full write-up: docs/local-llm-benchmarks.md.",
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 20,
+      "repetition_penalty": 1.0,
+      "presence_penalty": 0.0,
+
+      "_comment_reasoning_effort": "THE most important setting for this model. Qwen3.8's chat template adds reasoning_effort and DEFAULTS IT TO xhigh (chat_template.jinja:47). Measured on moria: xhigh burns the entire 8000-token budget over 401s and never emits an answer (finish_reason=length). On our 10-task coding eval, medium scored 8/10 using 31.8k tokens while xhigh scored 6/10 using 123.4k -- every extra failure was a truncation. More thinking is strictly worse here. medium is the default; pass reasoning_effort per-request to override.",
+      "chat_template_kwargs": { "reasoning_effort": "medium" },
+
+      "_comment_thinking_budget": "Hard stop, belt-and-braces with reasoning_effort. Even at medium one task ran to a 16k cap. reasoning_effort shapes intent; this bounds it.",
+      "thinking_budget_enabled": true,
+      "thinking_budget_tokens": 8192,
+
+      "_comment_no_speculative_decoding": "vlm_mtp with Qwen3.8-27B-MTP-4bit IS a real speedup here (1.43x on code, 1.19x avg) -- unlike our gemma MoE result -- because a dense 27B is genuinely bandwidth-bound. It is NOT enabled because we measured it is NOT lossless: with a verified determinism control (drafter off, same prompts, 3/3 identical across a restart), turning the drafter ON changed output on 2 of 3 prompts. Greedy verification is supposed to be bit-identical, so this looks like an oMLX 0.5.7 bug. Re-check with dot/omlx/bench/lossless_check.py after any oMLX upgrade."
+    },
     "Qwen3.6-35B-A3B-8bit": {
-      "description": "Unsloth-recommended sampling for Qwen3.6 coding/agentic tasks. Source: https://unsloth.ai/docs/models/qwen3.6 — also validated by multiple r/LocalLLaMA threads (see llm.md notes).",
+      "description": "SUPERSEDED by Qwen3.6-35B-A3B-4bit for general use -- measured 86.9 t/s here vs 130.7 t/s at 4-bit (a 1.50x penalty) for 35GB instead of 19GB. Kept because it is the target of the nix-managed -long-context symlink and as an 8-bit reference point. Unsloth-recommended sampling for Qwen3.6 coding/agentic tasks. Source: https://unsloth.ai/docs/models/qwen3.6 — also validated by multiple r/LocalLLaMA threads (see llm.md notes).",
       "temperature": 0.6,
       "top_p": 0.95,
       "top_k": 20,

--- a/dot/omlx/.stow-local-ignore
+++ b/dot/omlx/.stow-local-ignore
@@ -12,3 +12,4 @@ speculative-decoding-findings\.md
 \.omlx/cache
 \.omlx/logs
 \.omlx/models
+bench

--- a/dot/omlx/CLAUDE.md
+++ b/dot/omlx/CLAUDE.md
@@ -33,6 +33,31 @@ Available per-model fields (not exhaustive): `temperature`, `top_p`, `top_k`, `m
 
 There are also `model_profiles.json` (named presets per model) and `global_templates.json` (reusable templates across models), but we don't use those yet.
 
+## Which coding model to use
+
+**Default: `Qwen3.6-35B-A3B-4bit`** (MoE). Measured on moria at **130.7 t/s** decode vs the
+dense `Qwen3.8-27B-4bit`'s **23.0** — 5.7× — while scoring 9/10 vs 8/10 on a 10-task
+executable coding eval. Faster *and* not worse.
+
+**Specialist: `Qwen3.8-27B-4bit`** (dense, newer generation). Reach for it when A3B has
+actually failed a specific hard problem, or when output tokens are precious (31.8k vs 84.1k
+to solve the same eval). We did **not** measure a quality advantage — the eval ceilings out —
+so that case rests on its published benchmarks, not on our data.
+
+**Always prefer 4-bit over 8-bit**, but for different reasons per architecture: on a *dense*
+27B, 8-bit costs ~2× the speed (23.0 → 11.9 t/s); on the *MoE* it costs 1.50×
+(130.7 → 86.9) because only ~3B params are active per token. Cheaper, but not free — don't
+assume MoE 8-bit is a freebie. No 6-bit exists upstream for either.
+
+**Set `reasoning_effort` on Qwen3.8.** Its template defaults to `xhigh`, which on moria burns
+the whole token budget and never emits an answer. `model_settings.json` pins `medium` plus an
+8192-token budget. Measured: `medium` 8/10 in 27 min; `xhigh` 6/10 in 111 min — more thinking
+was strictly worse. Qwen3.6 has no such knob, so its token budget is the only guard.
+
+Full write-up (quant matrix, reasoning_effort study, speculative-decoding re-test, long-context
+prefill, and the seven measurement confounds that produced wrong numbers):
+**`docs/local-llm-benchmarks.md`**. Reproducible harness: **`bench/`**.
+
 ## Speculative Decoding & QAT
 
 **Don't add speculative decoding (MTP / DFlash / assistant drafters) to our Gemma MoE on

--- a/dot/omlx/bench/README.md
+++ b/dot/omlx/bench/README.md
@@ -1,0 +1,72 @@
+# oMLX benchmark harness
+
+The scripts behind `docs/local-llm-benchmarks.md`. Each is standalone and talks to a running
+oMLX server on `127.0.0.1:8000`.
+
+## Setup
+
+The key is read from `$OMLX_API_KEY`, or from an `omlx_key` file beside these scripts.
+**That file is gitignored — never commit it.** Every other secret in this repo goes through
+1Password / `op inject`; this is the one runtime credential that does not.
+
+```bash
+export OMLX_API_KEY=$(python3 -c "import json,os;print(json.load(
+  open(os.path.expanduser('~/.omlx/settings.json')))['auth']['api_key'])")
+```
+
+## Scripts
+
+| script | measures |
+|---|---|
+| `bench.py` | decode throughput + TTFT, 3 reps over code/prose/qa |
+| `codeeval.py` + `tasks.py` | 10 original coding tasks with executable assertion suites |
+| `effort.py` | token/latency cost of each `reasoning_effort` level |
+| `longctx.py` | prefill cost vs prompt length (~2K–64K) |
+| `lossless_check.py` | whether an optimization changes output at all |
+| `contention_audit.sh` | certifies a benchmark window had no foreign traffic |
+
+## Running
+
+```bash
+python3 bench.py Qwen3.6-35B-A3B-4bit --reps 3 --out out.json
+
+# these exact flags reproduce the headline eval numbers
+python3 codeeval.py Qwen3.6-35B-A3B-4bit --max-tokens 16000 --temperature 1.0 \
+    --extra '{"top_p":0.95,"top_k":20}' --reps 1 --out eval.json
+
+# Qwen3.8 needs its effort pinned or it will not terminate
+python3 codeeval.py Qwen3.8-27B-4bit --max-tokens 16000 --temperature 1.0 \
+    --extra '{"top_p":0.95,"top_k":20,"chat_template_kwargs":{"reasoning_effort":"medium"}}'
+
+python3 effort.py Qwen3.8-27B-4bit
+python3 longctx.py Qwen3.6-35B-A3B-4bit
+```
+
+## Measurement protocol — not optional
+
+Three confounds silently produced wrong numbers during this work. Skipping any of these
+reproduces them:
+
+1. **Restart oMLX before every measured model.** It keeps every model it has served resident;
+   a model measured alongside 69 GB of others read ~30% slow.
+2. **Stamp the window *after* the restart, and audit it.** A scheduled job on the same server
+   once depressed a measurement ~20% with nothing in the output to indicate it.
+   `contention_audit.sh` fails closed — an unparseable window or empty log is a hard error,
+   because a false "CLEAN" launders a bad run as verified.
+   ```bash
+   printf 'START %s\nEND %s\n' "$(date '+%F %T')" "$(date '+%F %T')" > window.txt
+   ./contention_audit.sh window.txt Qwen3.6-35B-A3B-4bit
+   ```
+3. **Never let the prefix cache serve your prefill.** `longctx.py` defends against this with a
+   per-prompt nonce, shuffled sizes, a warm-up, and a `cached_tokens == 0` check. If you write
+   a new long-context test, do the same — the tell that we got this wrong originally was a
+   4× longer prompt returning *faster*.
+
+Also: this is a live desktop. WindowServer and DisplayLink take a real GPU slice, so absolute
+numbers move ±20% between sessions. Trust ratios measured within one pass; re-measure the
+first model last to bound the drift.
+
+## Interpreting results
+
+`docs/local-llm-benchmarks.md` has a section defining every metric — what it measures, how it
+is computed, and what a high or low score actually means. Read it before quoting a number.

--- a/dot/omlx/bench/_key.py
+++ b/dot/omlx/bench/_key.py
@@ -1,0 +1,37 @@
+"""
+oMLX API key loading, shared by every script in this directory.
+
+Order: $OMLX_API_KEY, then a gitignored `omlx_key` file beside these scripts.
+The file is listed in dot/omlx/.gitignore and must never be committed — every
+other secret in this repo goes through 1Password / `op inject`, and this is the
+one runtime credential that does not.
+"""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_KEY_FILE = os.path.join(_HERE, "omlx_key")
+
+_HINT = """No oMLX API key found.
+
+Either export it:
+    export OMLX_API_KEY=...
+
+or write it to {path} (gitignored):
+    python3 -c "import json, os; print(json.load(
+        open(os.path.expanduser('~/.omlx/settings.json')))['auth']['api_key'])" > {path}
+"""
+
+
+def load_key():
+    key = os.environ.get("OMLX_API_KEY")
+    if key and key.strip():
+        return key.strip()
+    try:
+        with open(_KEY_FILE) as fh:
+            key = fh.read().strip()
+    except FileNotFoundError:
+        sys.exit(_HINT.format(path=_KEY_FILE))
+    if not key:
+        sys.exit(_HINT.format(path=_KEY_FILE))
+    return key

--- a/dot/omlx/bench/bench.py
+++ b/dot/omlx/bench/bench.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+oMLX decode-throughput A/B harness.
+
+Replicates the methodology of dot/omlx/speculative-decoding-findings.md:
+  matched A/B, same server instance, temperature 0, identical prompts,
+  prompt families = code / prose / qa, ~500 prompt tokens -> 200 completion tokens.
+
+Uses streaming so prefill (TTFT) and decode are measured separately:
+  decode_tps = (n_tokens - 1) / (t_last - t_first)
+which is the number bandwidth-bound analysis actually predicts.
+"""
+import json, sys, time, urllib.request, statistics, argparse, os
+
+BASE = "http://127.0.0.1:8000/v1"
+KEY = open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "omlx_key")).read().strip()
+
+# ---- prompt families (~500 prompt tokens each), mirroring the findings doc ----
+CODE = """You are reviewing a Python module. Here is the file:
+
+```python
+import asyncio, logging
+from dataclasses import dataclass, field
+from typing import Optional, Callable, Awaitable
+
+log = logging.getLogger(__name__)
+
+@dataclass
+class RetryPolicy:
+    attempts: int = 3
+    base_delay: float = 0.25
+    max_delay: float = 8.0
+    jitter: bool = True
+    retry_on: tuple = (TimeoutError, ConnectionError)
+
+@dataclass
+class Circuit:
+    failure_threshold: int = 5
+    reset_timeout: float = 30.0
+    _failures: int = field(default=0, init=False)
+    _opened_at: Optional[float] = field(default=None, init=False)
+
+    def allow(self) -> bool:
+        if self._opened_at is None:
+            return True
+        if (time.monotonic() - self._opened_at) > self.reset_timeout:
+            self._opened_at = None
+            self._failures = 0
+            return True
+        return False
+
+    def record_failure(self):
+        self._failures += 1
+        if self._failures >= self.failure_threshold:
+            self._opened_at = time.monotonic()
+
+    def record_success(self):
+        self._failures = 0
+        self._opened_at = None
+
+async def call_with_retry(fn: Callable[[], Awaitable], policy: RetryPolicy, circuit: Circuit):
+    last = None
+    for i in range(policy.attempts):
+        if not circuit.allow():
+            raise RuntimeError("circuit open")
+        try:
+            out = await fn()
+            circuit.record_success()
+            return out
+        except policy.retry_on as e:
+            last = e
+            circuit.record_failure()
+            delay = min(policy.base_delay * (2 ** i), policy.max_delay)
+            await asyncio.sleep(delay)
+    raise last
+```
+
+Write a corrected version of this module. Fix every bug you find and explain each fix briefly."""
+
+PROSE = """Write a clear, well-structured technical essay of several paragraphs on the following topic.
+
+Topic: The trade-offs of running large language models locally on consumer hardware versus
+calling a hosted API. Cover at minimum: capital cost versus marginal cost, data privacy and
+regulatory considerations, latency characteristics (time-to-first-token versus sustained
+throughput), the operational burden of model lifecycle management, how quantization changes
+the calculus, the role of unified memory architectures, and the situations in which a local
+model is strictly better, strictly worse, or genuinely a matter of taste. Be concrete and
+avoid marketing language. Assume the reader is an experienced software engineer who has not
+yet run a model locally but is technically fluent and skeptical of hype. Do not use bullet
+points; write flowing prose. Begin immediately with the essay itself, with no preamble."""
+
+QA = """Answer the following question thoroughly and precisely.
+
+Question: A colleague claims that speculative decoding will roughly double inference speed for
+any transformer model, on any hardware, as long as the drafter is small and fast. Explain
+carefully under what conditions this claim holds and under what conditions it fails. In your
+answer, address: what resource speculative decoding actually trades against what; why the
+arithmetic intensity of the decode step matters; how a mixture-of-experts model with a small
+number of active parameters per token differs from a dense model of the same total parameter
+count; why draft acceptance rate alone is not sufficient to predict speedup; and how a unified
+memory architecture with high bandwidth changes the picture relative to a discrete GPU with
+limited VRAM. Give a concrete rule of thumb an engineer could apply before investing effort."""
+
+PROMPTS = {"code": CODE, "prose": PROSE, "qa": QA}
+
+
+def stream_once(model, prompt, max_tokens=200, temperature=0.0, extra=None, timeout=1200):
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    if extra:
+        body.update(extra)
+    req = urllib.request.Request(
+        f"{BASE}/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"},
+    )
+    t0 = time.perf_counter()
+    t_first = None
+    t_last = None
+    n = 0
+    usage = None
+    text = []
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        for raw in r:
+            line = raw.decode("utf-8").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                ev = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if ev.get("usage"):
+                usage = ev["usage"]
+            for ch in ev.get("choices", []):
+                d = ch.get("delta", {}) or {}
+                piece = d.get("content") or d.get("reasoning_content") or ""
+                if piece:
+                    now = time.perf_counter()
+                    if t_first is None:
+                        t_first = now
+                    t_last = now
+                    n += 1
+                    text.append(piece)
+    t_end = time.perf_counter()
+    if t_first is None:
+        return None
+    wall = t_end - t0
+    ttft = t_first - t0
+    comp = (usage or {}).get("completion_tokens", n)
+    # oMLX batches several tokens into one SSE chunk, so chunk counts are NOT token
+    # counts. Derive decode rate from usage.completion_tokens and the post-prefill span.
+    decode_span = (wall - ttft) or 1e-9
+    return {
+        "ttft": ttft,
+        "wall": wall,
+        "chunks": n,
+        "completion_tokens": comp,
+        "prompt_tokens": (usage or {}).get("prompt_tokens"),
+        "prefill_tps": ((usage or {}).get("prompt_tokens") or 0) / ttft if ttft > 0 else 0.0,
+        # decode-only rate: excludes prefill
+        "decode_tps": comp / decode_span,
+        # end-to-end rate including prefill == the findings doc's
+        # "completion tokens / wall time"
+        "e2e_tps": comp / wall,
+        "text": "".join(text),
+    }
+
+
+def bench_model(model, reps=3, max_tokens=200, extra=None, families=None):
+    families = families or list(PROMPTS)
+    print(f"\n{'='*72}\nMODEL: {model}  (extra={extra})\n{'='*72}", flush=True)
+    # warm-up: forces load + kernel warm, discarded
+    w0 = time.perf_counter()
+    stream_once(model, "Hi.", max_tokens=8, extra=extra)
+    print(f"  [warm-up / load: {time.perf_counter()-w0:.1f}s]", flush=True)
+
+    out = {}
+    for fam in families:
+        runs = []
+        for i in range(reps):
+            r = stream_once(model, PROMPTS[fam], max_tokens=max_tokens, extra=extra)
+            if r:
+                runs.append(r)
+                print(
+                    f"  {fam:6s} run{i+1}: decode {r['decode_tps']:6.2f} t/s | "
+                    f"e2e {r['e2e_tps']:6.2f} t/s | ttft {r['ttft']:5.2f}s "
+                    f"(prefill {r['prefill_tps']:6.0f} t/s) | "
+                    f"in {r['prompt_tokens']} / out {r['completion_tokens']} tok",
+                    flush=True,
+                )
+        if runs:
+            out[fam] = {
+                "decode_tps": statistics.median(x["decode_tps"] for x in runs),
+                "e2e_tps": statistics.median(x["e2e_tps"] for x in runs),
+                "ttft": statistics.median(x["ttft"] for x in runs),
+                "prefill_tps": statistics.median(x["prefill_tps"] for x in runs),
+                "completion_tokens": runs[0]["completion_tokens"],
+                "prompt_tokens": runs[0]["prompt_tokens"],
+                "runs": [{k: v for k, v in x.items() if k != "text"} for x in runs],
+            }
+    if out:
+        print(
+            f"  --> MEDIAN decode: "
+            + "  ".join(f"{k}={v['decode_tps']:.2f}" for k, v in out.items())
+            + f"   AVG={statistics.mean(v['decode_tps'] for v in out.values()):.2f} t/s",
+            flush=True,
+        )
+    return out
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("models", nargs="+")
+    ap.add_argument("--reps", type=int, default=3)
+    ap.add_argument("--max-tokens", type=int, default=200)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    results = {}
+    for m in args.models:
+        try:
+            results[m] = bench_model(m, reps=args.reps, max_tokens=args.max_tokens)
+        except Exception as e:
+            print(f"  !! {m} failed: {type(e).__name__}: {e}", flush=True)
+            results[m] = {"error": f"{type(e).__name__}: {e}"}
+
+    if args.out:
+        slim = {
+            m: {f: {k: v for k, v in d.items() if k != "runs"} for f, d in r.items()}
+            if "error" not in r else r
+            for m, r in results.items()
+        }
+        with open(args.out, "w") as fh:
+            json.dump(slim, fh, indent=2)
+        print(f"\nwrote {args.out}", flush=True)

--- a/dot/omlx/bench/bench.py
+++ b/dot/omlx/bench/bench.py
@@ -7,13 +7,17 @@ Replicates the methodology of dot/omlx/speculative-decoding-findings.md:
   prompt families = code / prose / qa, ~500 prompt tokens -> 200 completion tokens.
 
 Uses streaming so prefill (TTFT) and decode are measured separately:
-  decode_tps = (n_tokens - 1) / (t_last - t_first)
-which is the number bandwidth-bound analysis actually predicts.
+  decode_tps = usage.completion_tokens / (wall - ttft)
+which is the number bandwidth-bound analysis actually predicts. Note the first
+token is emitted at the end of the prefill span, so this very slightly overstates
+decode for every model equally - it does not affect ratios.
 """
 import json, sys, time, urllib.request, statistics, argparse, os
 
 BASE = "http://127.0.0.1:8000/v1"
-KEY = open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "omlx_key")).read().strip()
+from _key import load_key
+
+KEY = load_key()
 
 # ---- prompt families (~500 prompt tokens each), mirroring the findings doc ----
 CODE = """You are reviewing a Python module. Here is the file:
@@ -155,7 +159,14 @@ def stream_once(model, prompt, max_tokens=200, temperature=0.0, extra=None, time
         return None
     wall = t_end - t0
     ttft = t_first - t0
-    comp = (usage or {}).get("completion_tokens", n)
+    comp = (usage or {}).get("completion_tokens")
+    if not comp:
+        # Never fall back to the chunk count: oMLX packs several tokens per SSE
+        # chunk, and doing so once produced a nonsensical "7 t/s decode" against
+        # a 22 t/s end-to-end rate. Fail loudly instead of reporting a wrong number.
+        raise RuntimeError(
+            "no usage.completion_tokens in stream (is stream_options.include_usage "
+            "honored by this server?) - refusing to guess from chunk counts")
     # oMLX batches several tokens into one SSE chunk, so chunk counts are NOT token
     # counts. Derive decode rate from usage.completion_tokens and the post-prefill span.
     decode_span = (wall - ttft) or 1e-9

--- a/dot/omlx/bench/codeeval.py
+++ b/dot/omlx/bench/codeeval.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Executable coding eval against oMLX models.
+
+For each task: prompt the model, extract the fenced python block, exec it in a
+subprocess, run the task's assertions, record pass/fail. Objective, no judging.
+"""
+import json, os, re, subprocess, sys, tempfile, time, urllib.request, argparse, statistics
+from tasks import TASKS
+
+BASE = "http://127.0.0.1:8000/v1"
+HERE = os.path.dirname(os.path.abspath(__file__))
+KEY = open(os.path.join(HERE, "omlx_key")).read().strip()
+
+FENCE = re.compile(r"```(?:python|py)?\s*\n(.*?)```", re.S)
+
+
+def extract_code(text):
+    blocks = FENCE.findall(text or "")
+    if blocks:
+        # concatenate all blocks: models sometimes split helper + main
+        return "\n\n".join(b.strip() for b in blocks)
+    return (text or "").strip()
+
+
+def call(model, prompt, max_tokens, temperature, extra=None, timeout=2400):
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    if extra:
+        body.update(extra)
+    req = urllib.request.Request(
+        f"{BASE}/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"},
+    )
+    t0 = time.perf_counter()
+    content, reasoning, usage, finish = [], [], None, None
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        for raw in r:
+            line = raw.decode("utf-8").strip()
+            if not line.startswith("data:"):
+                continue
+            p = line[5:].strip()
+            if p == "[DONE]":
+                break
+            try:
+                ev = json.loads(p)
+            except json.JSONDecodeError:
+                continue
+            if ev.get("usage"):
+                usage = ev["usage"]
+            for ch in ev.get("choices", []):
+                if ch.get("finish_reason"):
+                    finish = ch["finish_reason"]
+                d = ch.get("delta", {}) or {}
+                if d.get("content"):
+                    content.append(d["content"])
+                if d.get("reasoning_content"):
+                    reasoning.append(d["reasoning_content"])
+    return {
+        "content": "".join(content),
+        "reasoning_chars": len("".join(reasoning)),
+        "wall": time.perf_counter() - t0,
+        "usage": usage or {},
+        # 'length' means the token budget ran out -- with reasoning_effort defaulting to
+        # xhigh, a model can burn the whole budget thinking and never emit the answer.
+        # That is a truncation, not a wrong answer, and must be reported separately.
+        "finish": finish,
+    }
+
+
+RUNNER = """\
+import sys
+{code}
+
+# ---- tests ----
+{test}
+print("__PASS__")
+"""
+
+
+def run_code(code, test, timeout=25):
+    src = RUNNER.format(code=code, test=test)
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+        fh.write(src)
+        path = fh.name
+    try:
+        p = subprocess.run(
+            [sys.executable, path], capture_output=True, text=True, timeout=timeout
+        )
+        ok = "__PASS__" in p.stdout
+        err = (p.stderr or "").strip().splitlines()
+        return ok, ("" if ok else (err[-1] if err else "no output")[:300])
+    except subprocess.TimeoutExpired:
+        return False, "TIMEOUT"
+    finally:
+        os.unlink(path)
+
+
+def eval_model(model, max_tokens, temperature, extra=None, reps=1):
+    print(f"\n{'='*74}\nEVAL {model} (temp={temperature}, extra={extra})\n{'='*74}", flush=True)
+    rows = []
+    for t in TASKS:
+        for rep in range(reps):
+            try:
+                r = call(model, t["prompt"], max_tokens, temperature, extra)
+            except Exception as e:
+                print(f"  {t['name']:24s} rep{rep} CALL-FAIL {type(e).__name__}: {e}", flush=True)
+                rows.append({"task": t["name"], "rep": rep, "ok": False, "err": f"call:{e}"})
+                continue
+            code = extract_code(r["content"])
+            ok, err = run_code(code, t["test"])
+            ct = r["usage"].get("completion_tokens", 0)
+            rows.append(
+                {
+                    "task": t["name"], "rep": rep, "ok": ok, "err": err,
+                    "completion_tokens": ct,
+                    "reasoning_chars": r["reasoning_chars"],
+                    "wall": round(r["wall"], 1),
+                    "tps": round(ct / r["wall"], 2) if r["wall"] else 0,
+                    "finish": r["finish"],
+                }
+            )
+            trunc = " [TRUNCATED]" if r["finish"] == "length" else ""
+            print(
+                f"  {t['name']:24s} rep{rep} {'PASS' if ok else 'FAIL'} "
+                f"| {ct:5d} tok | {r['wall']:6.1f}s | {ct/r['wall'] if r['wall'] else 0:5.1f} t/s"
+                f"{trunc}" + ("" if ok else f" | {err[:80]}"),
+                flush=True,
+            )
+    n = len(rows)
+    passed = sum(1 for x in rows if x["ok"])
+    truncated = sum(1 for x in rows if x.get("finish") == "length")
+    toks = sum(x["completion_tokens"] for x in rows)
+    print(
+        f"  ==> {model}: {passed}/{n} = {100*passed/n:.1f}%"
+        f"   (truncated: {truncated}, total tokens spent: {toks})",
+        flush=True,
+    )
+    return {"model": model, "passed": passed, "total": n,
+            "truncated": truncated, "tokens": toks, "rows": rows}
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("models", nargs="+")
+    ap.add_argument("--max-tokens", type=int, default=8000)
+    ap.add_argument("--temperature", type=float, default=0.0)
+    ap.add_argument("--reps", type=int, default=1)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--extra", default=None, help="JSON merged into request body")
+    a = ap.parse_args()
+    extra = json.loads(a.extra) if a.extra else None
+
+    all_res = {}
+    for m in a.models:
+        all_res[m] = eval_model(m, a.max_tokens, a.temperature, extra, a.reps)
+        if a.out:
+            json.dump(all_res, open(a.out, "w"), indent=2)
+
+    print(f"\n{'='*74}\nSUMMARY\n{'='*74}")
+    for m, r in all_res.items():
+        print(f"  {m:34s} {r['passed']}/{r['total']}  ({100*r['passed']/r['total']:.1f}%)"
+              f"  truncated={r.get('truncated',0)}  tokens={r.get('tokens',0)}")

--- a/dot/omlx/bench/codeeval.py
+++ b/dot/omlx/bench/codeeval.py
@@ -10,17 +10,30 @@ from tasks import TASKS
 
 BASE = "http://127.0.0.1:8000/v1"
 HERE = os.path.dirname(os.path.abspath(__file__))
-KEY = open(os.path.join(HERE, "omlx_key")).read().strip()
+from _key import load_key
 
-FENCE = re.compile(r"```(?:python|py)?\s*\n(.*?)```", re.S)
+KEY = load_key()
+
+PY_FENCE = re.compile(r"```(?:python|py)[ \t]*\r?\n(.*?)```", re.S)
+BARE_FENCE = re.compile(r"```[ \t]*\r?\n(.*?)```", re.S)
 
 
 def extract_code(text):
-    blocks = FENCE.findall(text or "")
-    if blocks:
-        # concatenate all blocks: models sometimes split helper + main
-        return "\n\n".join(b.strip() for b in blocks)
-    return (text or "").strip()
+    """Pull the solution out of a model response.
+
+    Prefer explicitly python-tagged fences: concatenating *every* fence
+    (including ```bash or an "example usage" block that prints or asserts)
+    manufactures false failures and biases against verbose models. Fall back
+    to untagged fences, then to the raw text.
+    """
+    text = text or ""
+    tagged = PY_FENCE.findall(text)
+    if tagged:
+        return "\n\n".join(b.strip() for b in tagged)
+    untagged = BARE_FENCE.findall(text)
+    if untagged:
+        return "\n\n".join(b.strip() for b in untagged)
+    return text.strip()
 
 
 def call(model, prompt, max_tokens, temperature, extra=None, timeout=2400):
@@ -137,7 +150,7 @@ def eval_model(model, max_tokens, temperature, extra=None, reps=1):
     n = len(rows)
     passed = sum(1 for x in rows if x["ok"])
     truncated = sum(1 for x in rows if x.get("finish") == "length")
-    toks = sum(x["completion_tokens"] for x in rows)
+    toks = sum(x.get("completion_tokens", 0) for x in rows)
     print(
         f"  ==> {model}: {passed}/{n} = {100*passed/n:.1f}%"
         f"   (truncated: {truncated}, total tokens spent: {toks})",

--- a/dot/omlx/bench/contention_audit.sh
+++ b/dot/omlx/bench/contention_audit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Audit a benchmark window for foreign traffic on the shared oMLX server.
+# Usage: contention_audit.sh <window-file> <expected-model-substring>
+# Prints any Chat completion served in the window whose model does NOT match.
+set -u
+W="${1:-final_window.txt}"
+EXPECT="${2:-Qwen3.}"
+LOG="$HOME/Library/Logs/omlx.log"
+
+START=$(awk '/START/{print $3}' "$W")
+END=$(awk '/END/{print $3}' "$W")
+echo "window: $START -> $END   (expecting only models matching '$EXPECT')"
+
+grep "Chat completion: model=" "$LOG" \
+  | awk -v s="$START" -v e="$END" '{t=substr($2,1,8)} t>=s && t<=e' \
+  | grep -v "model=$EXPECT" \
+  | sed 's/.*model=/  FOREIGN: /' | sort | uniq -c
+
+n=$(grep "Chat completion: model=" "$LOG" \
+      | awk -v s="$START" -v e="$END" '{t=substr($2,1,8)} t>=s && t<=e' \
+      | grep -vc "model=$EXPECT")
+if [ "$n" -eq 0 ]; then echo "  CLEAN - no foreign requests in window"; else echo "  !! $n foreign requests - results suspect"; fi

--- a/dot/omlx/bench/contention_audit.sh
+++ b/dot/omlx/bench/contention_audit.sh
@@ -1,22 +1,65 @@
 #!/bin/bash
 # Audit a benchmark window for foreign traffic on the shared oMLX server.
-# Usage: contention_audit.sh <window-file> <expected-model-substring>
-# Prints any Chat completion served in the window whose model does NOT match.
+#
+# Why this exists: roger's digest job once hammered gpt-oss-120b on the same
+# server during a benchmark and silently depressed one model's measurement by
+# ~20%. Nothing in the benchmark output hinted at it.
+#
+# This script MUST fail closed. A false "CLEAN" is worse than no check at all,
+# because it launders a contaminated run as verified. Every parse failure below
+# is therefore a hard exit, not a warning.
+#
+# Usage: contention_audit.sh <window-file> <expected-model-id>
+#   <window-file>      two lines, as written by the bench drivers:
+#                        START 2026-08-15 17:25:53
+#                        END 2026-08-15 17:35:39
+#   <expected-model-id> EXACT model id under test, e.g. Qwen3.8-27B-4bit.
+#                       Anything else served in the window is foreign --
+#                       including a different Qwen, which is exactly the
+#                       engine-pool-residency confound.
 set -u
-W="${1:-final_window.txt}"
-EXPECT="${2:-Qwen3.}"
-LOG="$HOME/Library/Logs/omlx.log"
 
-START=$(awk '/START/{print $3}' "$W")
-END=$(awk '/END/{print $3}' "$W")
-echo "window: $START -> $END   (expecting only models matching '$EXPECT')"
+W="${1:-}"
+EXPECT="${2:-}"
+LOG="${OMLX_LOG:-$HOME/Library/Logs/omlx.log}"
 
-grep "Chat completion: model=" "$LOG" \
+die () { echo "FATAL: $*" >&2; exit 2; }
+
+[ -n "$W" ] && [ -n "$EXPECT" ] || die "usage: $(basename "$0") <window-file> <expected-model-id>"
+[ -r "$W" ]   || die "window file not readable: $W"
+[ -r "$LOG" ] || die "oMLX log not readable: $LOG (set OMLX_LOG to override)"
+
+# Time is the LAST field on each line, so this survives both
+# "START 17:25:53" and "START 2026-08-15 17:25:53".
+START=$(awk '/^START/{print $NF}' "$W")
+END=$(awk '/^END/{print $NF}'   "$W")
+
+[ -n "$START" ] || die "could not parse START from $W (expected a line beginning 'START')"
+[ -n "$END" ]   || die "could not parse END from $W (expected a line beginning 'END'). \
+An unfinished run has no END - the benchmark may still be running."
+
+echo "window: $START -> $END   (expected model: $EXPECT)"
+
+# Substring-match the model id, then exclude exact matches for the expected one.
+# awk compares HH:MM:SS lexically, which is correct for zero-padded times within a day.
+foreign=$(grep "Chat completion: model=" "$LOG" \
   | awk -v s="$START" -v e="$END" '{t=substr($2,1,8)} t>=s && t<=e' \
-  | grep -v "model=$EXPECT" \
-  | sed 's/.*model=/  FOREIGN: /' | sort | uniq -c
+  | sed 's/.*model=\([^,]*\),.*/\1/' \
+  | grep -vxF "$EXPECT" || true)
 
-n=$(grep "Chat completion: model=" "$LOG" \
-      | awk -v s="$START" -v e="$END" '{t=substr($2,1,8)} t>=s && t<=e' \
-      | grep -vc "model=$EXPECT")
-if [ "$n" -eq 0 ]; then echo "  CLEAN - no foreign requests in window"; else echo "  !! $n foreign requests - results suspect"; fi
+total=$(grep "Chat completion: model=" "$LOG" \
+  | awk -v s="$START" -v e="$END" '{t=substr($2,1,8)} t>=s && t<=e' | wc -l | tr -d ' ')
+
+if [ "$total" -eq 0 ]; then
+  die "no requests at all in window $START-$END. Either the window is wrong or the \
+log rotated - refusing to report CLEAN on an empty window."
+fi
+
+n=$(printf '%s' "$foreign" | grep -c . || true)
+if [ "$n" -eq 0 ]; then
+  echo "  CLEAN - $total requests in window, all $EXPECT"
+  exit 0
+fi
+echo "  !! $n of $total requests were FOREIGN - results are suspect:"
+printf '%s\n' "$foreign" | sort | uniq -c | sed 's/^/    /'
+exit 1

--- a/dot/omlx/bench/effort.py
+++ b/dot/omlx/bench/effort.py
@@ -11,7 +11,9 @@ import json, sys, time, urllib.request, os, statistics
 
 BASE = "http://127.0.0.1:8000/v1"
 HERE = os.path.dirname(os.path.abspath(__file__))
-KEY = open(os.path.join(HERE, "omlx_key")).read().strip()
+from _key import load_key
+
+KEY = load_key()
 MODEL = sys.argv[1] if len(sys.argv) > 1 else "Qwen3.8-27B-4bit"
 
 PROMPT = (

--- a/dot/omlx/bench/effort.py
+++ b/dot/omlx/bench/effort.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Measure the cost of Qwen3.8's reasoning_effort levels.
+
+The chat template defaults reasoning_effort to 'xhigh' (chat_template.jinja:47),
+so an unconfigured Qwen3.8 spends the maximum on thinking for every request.
+This measures how many tokens each level actually burns, and the wall-clock to a
+finished answer -- which is what latency feels like, not raw tok/s.
+"""
+import json, sys, time, urllib.request, os, statistics
+
+BASE = "http://127.0.0.1:8000/v1"
+HERE = os.path.dirname(os.path.abspath(__file__))
+KEY = open(os.path.join(HERE, "omlx_key")).read().strip()
+MODEL = sys.argv[1] if len(sys.argv) > 1 else "Qwen3.8-27B-4bit"
+
+PROMPT = (
+    "A Python service intermittently returns stale data. It runs 4 gunicorn workers, "
+    "each with an in-process dict cache keyed by user id, invalidated on write. "
+    "Writes go through a single Postgres primary. Diagnose the most likely root cause "
+    "and give the two smallest correct fixes."
+)
+
+
+def once(effort, enable_thinking=True, max_tokens=8000):
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": PROMPT}],
+        "max_tokens": max_tokens,
+        "temperature": 1.0, "top_p": 0.95, "top_k": 20,
+    }
+    kw = {}
+    if effort is not None:
+        kw["reasoning_effort"] = effort
+    if not enable_thinking:
+        kw["enable_thinking"] = False
+    if kw:
+        body["chat_template_kwargs"] = kw
+    req = urllib.request.Request(
+        f"{BASE}/chat/completions", data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"},
+    )
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=1800) as r:
+        d = json.load(r)
+    wall = time.perf_counter() - t0
+    msg = d["choices"][0]["message"]
+    u = d.get("usage", {})
+    think = msg.get("reasoning_content") or ""
+    ans = msg.get("content") or ""
+    return {
+        "effort": effort if effort else ("no-think" if not enable_thinking else "default"),
+        "wall": wall,
+        "completion_tokens": u.get("completion_tokens"),
+        "think_chars": len(think),
+        "answer_chars": len(ans),
+        "finish": d["choices"][0].get("finish_reason"),
+        "tps": (u.get("completion_tokens") or 0) / wall,
+    }
+
+
+if __name__ == "__main__":
+    print(f"model={MODEL}\n")
+    rows = []
+    trials = [
+        (None, True),        # template default (= xhigh)
+        ("low", True),
+        ("medium", True),
+        ("xhigh", True),
+        (None, False),       # thinking disabled
+    ]
+    for effort, think in trials:
+        try:
+            r = once(effort, think)
+            rows.append(r)
+            print(
+                f"  {r['effort']:9s} | {r['completion_tokens']:6} tok | {r['wall']:7.1f}s "
+                f"| {r['tps']:5.1f} t/s | think {r['think_chars']:6} ch | ans {r['answer_chars']:5} ch "
+                f"| {r['finish']}",
+                flush=True,
+            )
+        except Exception as e:
+            print(f"  {str(effort):9s} FAILED {type(e).__name__}: {e}", flush=True)
+    json.dump(rows, open(os.path.join(HERE, "effort.json"), "w"), indent=2)

--- a/dot/omlx/bench/longctx.py
+++ b/dot/omlx/bench/longctx.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Long-context prefill cost.
+
+For a coding agent the felt latency is usually PREFILL, not decode: you paste a
+40k-token repo context and wait for the first token. Decode t/s says nothing about
+that. This measures TTFT vs prompt length.
+
+Qwen3.8/3.6-27B are hybrid: only 16 of 64 layers carry a real KV cache
+(full_attention_interval 4), so long context should be cheaper than a conventional
+dense 27B. This checks whether that shows up in practice.
+"""
+import json, os, sys, time, urllib.request
+
+BASE = "http://127.0.0.1:8000/v1"
+HERE = os.path.dirname(os.path.abspath(__file__))
+KEY = open(os.path.join(HERE, "omlx_key")).read().strip()
+MODEL = sys.argv[1] if len(sys.argv) > 1 else "Qwen3.8-27B-4bit"
+
+# A chunk of plausible source-like text; repeated to hit target lengths.
+CHUNK = '''
+def process_batch(records, *, validate=True, on_error="skip"):
+    """Normalize a batch of records and return (ok, failed)."""
+    ok, failed = [], []
+    for i, rec in enumerate(records):
+        try:
+            if validate and not isinstance(rec, dict):
+                raise TypeError(f"record {i} is {type(rec).__name__}, expected dict")
+            out = {k.strip().lower(): v for k, v in rec.items() if v is not None}
+            if "id" not in out:
+                raise KeyError(f"record {i} missing id")
+            ok.append(out)
+        except Exception as exc:
+            if on_error == "raise":
+                raise
+            failed.append((i, repr(exc)))
+    return ok, failed
+'''
+
+
+def build(target_tokens):
+    # ~4 chars/token is close enough for MLX tokenizers on code-like text
+    reps = max(1, (target_tokens * 4) // len(CHUNK))
+    return ("Here is a source file:\n\n" + CHUNK * reps +
+            "\n\nName the single most likely bug in process_batch. One sentence.")
+
+
+def once(prompt, max_tokens=24):
+    body = {"model": MODEL, "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens, "temperature": 0.0,
+            "chat_template_kwargs": {"enable_thinking": False}}
+    req = urllib.request.Request(
+        f"{BASE}/chat/completions", data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"})
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=3600) as r:
+        d = json.load(r)
+    wall = time.perf_counter() - t0
+    u = d.get("usage", {})
+    return u.get("prompt_tokens"), u.get("completion_tokens"), wall
+
+
+if __name__ == "__main__":
+    print(f"model={MODEL}   (thinking disabled; output capped so wall ~= prefill)\n")
+    rows = []
+    for target in (2000, 8000, 16000, 32000, 64000):
+        try:
+            pt, ct, wall = once(build(target))
+            tps = pt / wall if wall else 0
+            rows.append({"prompt_tokens": pt, "completion_tokens": ct,
+                         "wall": round(wall, 2), "prefill_tps": round(tps, 1)})
+            print(f"  {pt:7d} prompt tok -> {wall:7.2f}s   ({tps:7.0f} tok/s prefill), out {ct}",
+                  flush=True)
+        except Exception as e:
+            print(f"  target {target}: FAILED {type(e).__name__}: {e}", flush=True)
+            break
+    json.dump(rows, open(os.path.join(HERE, f"longctx_{MODEL}.json"), "w"), indent=2)

--- a/dot/omlx/bench/longctx.py
+++ b/dot/omlx/bench/longctx.py
@@ -9,12 +9,28 @@ that. This measures TTFT vs prompt length.
 Qwen3.8/3.6-27B are hybrid: only 16 of 64 layers carry a real KV cache
 (full_attention_interval 4), so long context should be cheaper than a conventional
 dense 27B. This checks whether that shows up in practice.
+
+MEASUREMENT HAZARD -- the reason this script looks the way it does. oMLX runs a
+prefix cache (32 GB hot cache on moria). An earlier version built each prompt as
+`header + CHUNK*reps + question` and walked the sizes in ascending order, so every
+prompt was a strict prefix-extension of the previous one and got most of its prefill
+served from cache. The tell was unmistakable in the output: a 7,862-token prompt
+came back FASTER in wall-clock than a 1,946-token one. Those numbers measured the
+cache, not prefill.
+
+Two defences here:
+  1. Every prompt gets a unique random nonce in its FIRST line, so no prompt is a
+     prefix of any other and nothing can be served from a previous request.
+  2. Sizes are visited in shuffled order, and a warm-up request absorbs model load,
+     so any residual ordering effect cannot masquerade as a size trend.
 """
 import json, os, sys, time, urllib.request
 
 BASE = "http://127.0.0.1:8000/v1"
 HERE = os.path.dirname(os.path.abspath(__file__))
-KEY = open(os.path.join(HERE, "omlx_key")).read().strip()
+from _key import load_key
+
+KEY = load_key()
 MODEL = sys.argv[1] if len(sys.argv) > 1 else "Qwen3.8-27B-4bit"
 
 # A chunk of plausible source-like text; repeated to hit target lengths.
@@ -38,10 +54,11 @@ def process_batch(records, *, validate=True, on_error="skip"):
 '''
 
 
-def build(target_tokens):
-    # ~4 chars/token is close enough for MLX tokenizers on code-like text
+def build(target_tokens, nonce):
+    # ~4 chars/token is close enough for MLX tokenizers on code-like text.
+    # The nonce goes FIRST so this prompt shares no prefix with any other.
     reps = max(1, (target_tokens * 4) // len(CHUNK))
-    return ("Here is a source file:\n\n" + CHUNK * reps +
+    return (f"Session {nonce}. Here is a source file:\n\n" + CHUNK * reps +
             "\n\nName the single most likely bug in process_batch. One sentence.")
 
 
@@ -57,21 +74,35 @@ def once(prompt, max_tokens=24):
         d = json.load(r)
     wall = time.perf_counter() - t0
     u = d.get("usage", {})
-    return u.get("prompt_tokens"), u.get("completion_tokens"), wall
+    cached = (u.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
+    return u.get("prompt_tokens"), u.get("completion_tokens"), wall, cached
 
 
 if __name__ == "__main__":
-    print(f"model={MODEL}   (thinking disabled; output capped so wall ~= prefill)\n")
+    import random, secrets
+    print(f"model={MODEL}   (thinking disabled; output capped so wall ~= prefill)")
+    print("unique nonce per prompt + shuffled order => no prefix-cache reuse\n")
+
+    # warm-up: absorb model load so it cannot be charged to the first size
+    once(build(500, secrets.token_hex(8)))  # returns 4-tuple; discarded
+
+    targets = [2000, 8000, 16000, 32000, 64000]
+    random.shuffle(targets)
     rows = []
-    for target in (2000, 8000, 16000, 32000, 64000):
+    for target in targets:
         try:
-            pt, ct, wall = once(build(target))
+            pt, ct, wall, cached = once(build(target, secrets.token_hex(8)))
             tps = pt / wall if wall else 0
             rows.append({"prompt_tokens": pt, "completion_tokens": ct,
-                         "wall": round(wall, 2), "prefill_tps": round(tps, 1)})
-            print(f"  {pt:7d} prompt tok -> {wall:7.2f}s   ({tps:7.0f} tok/s prefill), out {ct}",
-                  flush=True)
+                         "wall": round(wall, 2), "prefill_tps": round(tps, 1),
+                         "cached_tokens": cached})
+            # cached_tokens MUST be ~0; anything else means we measured the cache
+            flag = "" if cached == 0 else f"  <-- WARNING {cached} CACHED, not a cold prefill"
+            print(f"  {pt:7d} prompt tok -> {wall:7.2f}s   ({tps:7.0f} tok/s prefill), "
+                  f"out {ct}, cached {cached}{flag}", flush=True)
         except Exception as e:
             print(f"  target {target}: FAILED {type(e).__name__}: {e}", flush=True)
             break
-    json.dump(rows, open(os.path.join(HERE, f"longctx_{MODEL}.json"), "w"), indent=2)
+    rows.sort(key=lambda r: r["prompt_tokens"])
+    safe = MODEL.replace("/", "_")
+    json.dump(rows, open(os.path.join(HERE, f"longctx_{safe}.json"), "w"), indent=2)

--- a/dot/omlx/bench/lossless_check.py
+++ b/dot/omlx/bench/lossless_check.py
@@ -14,7 +14,9 @@ import hashlib, json, os, sys, urllib.request
 
 BASE = "http://127.0.0.1:8000/v1"
 HERE = os.path.dirname(os.path.abspath(__file__))
-KEY = open(os.path.join(HERE, "omlx_key")).read().strip()
+from _key import load_key
+
+KEY = load_key()
 
 PROMPTS = [
     "Write a Python function to merge overlapping intervals. Explain the algorithm.",

--- a/dot/omlx/bench/lossless_check.py
+++ b/dot/omlx/bench/lossless_check.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Capture greedy output from a model and hash it.
+
+Speculative decoding with greedy verification is lossless BY CONSTRUCTION -- the
+target accepts only the prefix it would itself have produced. This turns that claim
+into evidence: run with the drafter off, run with it on, compare hashes.
+
+Usage:
+    lossless_check.py <model> <label>     # writes lossless_<label>.json
+    lossless_check.py --compare a b       # compares two captures
+"""
+import hashlib, json, os, sys, urllib.request
+
+BASE = "http://127.0.0.1:8000/v1"
+HERE = os.path.dirname(os.path.abspath(__file__))
+KEY = open(os.path.join(HERE, "omlx_key")).read().strip()
+
+PROMPTS = [
+    "Write a Python function to merge overlapping intervals. Explain the algorithm.",
+    "List the first 12 primes and explain the sieve of Eratosthenes.",
+    "Explain the difference between a process and a thread.",
+]
+
+
+def gen(model, prompt, max_tokens=180):
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,          # greedy => deterministic => comparable
+    }
+    req = urllib.request.Request(
+        f"{BASE}/chat/completions", data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=1800) as r:
+        d = json.load(r)
+    m = d["choices"][0]["message"]
+    return (m.get("reasoning_content") or "") + "\x00" + (m.get("content") or "")
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "--compare":
+        a = json.load(open(os.path.join(HERE, f"lossless_{sys.argv[2]}.json")))
+        b = json.load(open(os.path.join(HERE, f"lossless_{sys.argv[3]}.json")))
+        same = 0
+        for i, (x, y) in enumerate(zip(a, b)):
+            ok = x["sha"] == y["sha"]
+            same += ok
+            print(f"  prompt {i}: {'IDENTICAL' if ok else 'DIFFERS'}  ({x['sha'][:12]} vs {y['sha'][:12]})")
+        print(f"  => {same}/{len(a)} identical "
+              f"({'LOSSLESS' if same == len(a) else 'NOT lossless - investigate'})")
+    else:
+        model, label = sys.argv[1], sys.argv[2]
+        out = []
+        for p in PROMPTS:
+            t = gen(model, p)
+            out.append({"sha": hashlib.sha256(t.encode()).hexdigest(), "chars": len(t)})
+            print(f"  captured {out[-1]['sha'][:12]} ({out[-1]['chars']} ch)", flush=True)
+        json.dump(out, open(os.path.join(HERE, f"lossless_{label}.json"), "w"), indent=2)

--- a/dot/omlx/bench/tasks.py
+++ b/dot/omlx/bench/tasks.py
@@ -1,0 +1,483 @@
+"""
+Original coding tasks with executable unit tests.
+
+Written fresh (not HumanEval/MBPP) to reduce benchmark-contamination risk, and
+skewed toward the failure modes that matter for agentic coding: edge cases,
+precise spec-following, and stateful/algorithmic reasoning rather than one-liners.
+
+Each task: prompt -> model emits a fenced python block -> we exec it, then run
+`test()`. Score = fraction of tasks whose test() completes without raising.
+"""
+
+TASKS = [
+    {
+        "name": "interval_merge_weighted",
+        "prompt": """Write a Python function:
+
+    def merge_weighted(intervals: list[tuple[int, int, int]]) -> list[tuple[int, int, int]]:
+
+`intervals` is a list of (start, end, weight) with start < end, half-open [start, end).
+Intervals may overlap arbitrarily and are not sorted.
+
+Return the minimal list of non-overlapping half-open intervals covering exactly the
+same points, where each output interval carries the SUM of the weights of all input
+intervals covering it. Output must be sorted by start. Adjacent output intervals that
+share the same weight must be merged into one. Gaps (points covered by no input) must
+NOT appear in the output.
+
+Example:
+    merge_weighted([(0, 5, 1), (2, 8, 10)]) == [(0, 2, 1), (2, 5, 11), (5, 8, 10)]
+    merge_weighted([(0, 2, 3), (2, 4, 3)])  == [(0, 4, 3)]
+    merge_weighted([])                      == []
+
+Return ONLY a fenced python code block containing the function.""",
+        "test": """
+assert merge_weighted([(0,5,1),(2,8,10)]) == [(0,2,1),(2,5,11),(5,8,10)]
+assert merge_weighted([(0,2,3),(2,4,3)]) == [(0,4,3)]
+assert merge_weighted([]) == []
+assert merge_weighted([(0,1,5)]) == [(0,1,5)]
+# disjoint with a gap -> gap absent
+assert merge_weighted([(0,2,1),(5,7,2)]) == [(0,2,1),(5,7,2)]
+# triple overlap
+assert merge_weighted([(0,10,1),(2,8,2),(4,6,4)]) == [(0,2,1),(2,4,3),(4,6,7),(6,8,3),(8,10,1)]
+# identical intervals stack
+assert merge_weighted([(0,3,2),(0,3,2)]) == [(0,3,4)]
+# unsorted input
+assert merge_weighted([(5,7,2),(0,2,1)]) == [(0,2,1),(5,7,2)]
+# merging equal adjacent weights across a boundary
+assert merge_weighted([(0,4,1),(4,8,1),(8,12,1)]) == [(0,12,1)]
+""",
+    },
+    {
+        "name": "topo_sort_stable",
+        "prompt": """Write a Python function:
+
+    def stable_toposort(nodes: list[str], edges: list[tuple[str, str]]) -> list[str] | None:
+
+`nodes` is a list of unique node names in their original declared order.
+`edges` is a list of (a, b) meaning "a must come before b".
+
+Return a topological ordering. Among all valid orderings, return the one that is
+lexicographically smallest with respect to the ORIGINAL INDEX of each node in `nodes`
+(i.e. whenever several nodes are simultaneously available, always emit the one that
+appeared earliest in `nodes`). If a cycle makes ordering impossible, return None.
+
+Edges referencing unknown nodes should be ignored. Duplicate edges are allowed.
+
+Return ONLY a fenced python code block containing the function.""",
+        "test": """
+assert stable_toposort(["a","b","c"], []) == ["a","b","c"]
+assert stable_toposort(["c","b","a"], []) == ["c","b","a"]
+assert stable_toposort(["a","b","c"], [("c","a")]) == ["b","c","a"]
+assert stable_toposort(["a","b"], [("a","b"),("b","a")]) is None
+assert stable_toposort([], []) == []
+assert stable_toposort(["a","b","c"], [("a","z")]) == ["a","b","c"]
+assert stable_toposort(["a","b","c"], [("a","b"),("a","b")]) == ["a","b","c"]
+# earliest-declared tie-break under constraint
+assert stable_toposort(["x","y","z"], [("z","y")]) == ["x","z","y"]
+r = stable_toposort(["d","c","b","a"], [("a","b"),("b","c")])
+assert r == ["d","a","b","c"], r
+# self-loop is a cycle
+assert stable_toposort(["a"], [("a","a")]) is None
+""",
+    },
+    {
+        "name": "semver_range",
+        "prompt": """Write a Python function:
+
+    def satisfies(version: str, spec: str) -> bool:
+
+Implement a subset of npm-style semver matching. `version` is "MAJOR.MINOR.PATCH"
+(all non-negative integers, no pre-release tags).
+
+`spec` is one of:
+  - "*"            -> matches any version
+  - "1.2.3"        -> exact match
+  - "^1.2.3"       -> >=1.2.3 and < the next MAJOR (2.0.0). BUT if major is 0, caret
+                      pins the minor: ^0.2.3 means >=0.2.3 and <0.3.0.
+                      And ^0.0.3 means >=0.0.3 and <0.0.4.
+  - "~1.2.3"       -> >=1.2.3 and <1.3.0 (pins minor)
+  - ">=1.2.3", ">1.2.3", "<=1.2.3", "<1.2.3"  -> ordinary comparisons
+
+Comparison is numeric per component (so 1.10.0 > 1.9.0). Whitespace around the spec
+should be tolerated. Return True/False.
+
+Return ONLY a fenced python code block containing the function.""",
+        "test": """
+assert satisfies("1.2.3", "*") is True
+assert satisfies("1.2.3", "1.2.3") is True
+assert satisfies("1.2.4", "1.2.3") is False
+assert satisfies("1.9.0", ">1.10.0") is False
+assert satisfies("1.10.0", ">1.9.0") is True
+assert satisfies("1.2.3", "^1.2.3") is True
+assert satisfies("1.9.9", "^1.2.3") is True
+assert satisfies("2.0.0", "^1.2.3") is False
+assert satisfies("1.2.2", "^1.2.3") is False
+# caret with major 0 pins minor
+assert satisfies("0.2.9", "^0.2.3") is True
+assert satisfies("0.3.0", "^0.2.3") is False
+# caret with major 0 minor 0 pins patch
+assert satisfies("0.0.3", "^0.0.3") is True
+assert satisfies("0.0.4", "^0.0.3") is False
+# tilde
+assert satisfies("1.2.9", "~1.2.3") is True
+assert satisfies("1.3.0", "~1.2.3") is False
+# comparators + whitespace
+assert satisfies("1.2.3", "  >=1.2.3 ") is True
+assert satisfies("1.2.3", "<=1.2.3") is True
+assert satisfies("1.2.3", "<1.2.3") is False
+""",
+    },
+    {
+        "name": "lru_ttl_cache",
+        "prompt": """Write a Python class:
+
+    class LRUTTLCache:
+        def __init__(self, capacity: int, clock): ...
+        def put(self, key, value, ttl: float | None = None) -> None: ...
+        def get(self, key): ...
+        def __len__(self) -> int: ...
+
+A least-recently-used cache with optional per-entry TTL.
+
+- `clock` is a zero-argument callable returning a float "now" (so tests can control time).
+- `put(k, v, ttl)`: insert/update. If `ttl` is not None the entry expires at now+ttl.
+  Updating an existing key refreshes its value, its TTL, and its recency.
+- `get(k)`: return the value, or None if missing or expired. A successful get refreshes
+  recency. An expired entry must be removed as a side effect.
+- When inserting a NEW key would exceed `capacity`, first drop any entries that are
+  already expired; if still over capacity, evict the least-recently-used entry.
+- `__len__` returns the number of live (non-expired) entries; it must not count
+  expired ones, and it should purge them.
+
+Return ONLY a fenced python code block containing the class.""",
+        "test": """
+t = {"now": 0.0}
+clk = lambda: t["now"]
+c = LRUTTLCache(2, clk)
+c.put("a", 1); c.put("b", 2)
+assert c.get("a") == 1
+c.put("c", 3)              # 'b' is LRU (a was just read) -> evict b
+assert c.get("b") is None
+assert c.get("a") == 1 and c.get("c") == 3
+assert len(c) == 2
+
+# ttl expiry
+c2 = LRUTTLCache(10, clk)
+c2.put("x", 1, ttl=5)
+t["now"] = 4.9
+assert c2.get("x") == 1
+t["now"] = 5.1
+assert c2.get("x") is None
+assert len(c2) == 0
+
+# update refreshes ttl and recency
+t["now"] = 0.0
+c3 = LRUTTLCache(2, clk)
+c3.put("a", 1, ttl=10); c3.put("b", 2)
+t["now"] = 5.0
+c3.put("a", 99, ttl=10)     # refresh a
+t["now"] = 12.0
+assert c3.get("a") == 99     # still alive (expires at 15)
+assert len(c3) == 2
+
+# expired entries are dropped before LRU eviction
+t["now"] = 0.0
+c4 = LRUTTLCache(2, clk)
+c4.put("old", 1, ttl=1)
+c4.put("keep", 2)
+t["now"] = 2.0
+c4.put("new", 3)
+assert c4.get("keep") == 2
+assert c4.get("new") == 3
+assert c4.get("old") is None
+""",
+    },
+    {
+        "name": "parse_ini_nested",
+        "prompt": """Write a Python function:
+
+    def parse_config(text: str) -> dict:
+
+Parse a small INI-like config format into nested dicts.
+
+Rules:
+- Lines that are blank or whose first non-space character is '#' or ';' are ignored.
+- A line like `[a.b.c]` opens a section; it creates nested dicts: result["a"]["b"]["c"].
+- `key = value` assigns into the current section (or top level before any section header).
+- Keys and values are stripped of surrounding whitespace.
+- The FIRST '=' splits the line; later '=' characters belong to the value.
+- Values are coerced: "true"/"false" (case-insensitive) -> bool; a valid int -> int;
+  a valid float -> float; otherwise str.
+- A value wrapped in matching single or double quotes is always a string, with the
+  quotes removed and NO coercion applied.
+- A later assignment to the same key in the same section overwrites the earlier one.
+- Re-opening an existing section merges into it rather than replacing it.
+
+Return ONLY a fenced python code block containing the function.""",
+        "test": """
+cfg = parse_config('''
+# comment
+; also comment
+top = 1
+
+[server]
+host = "localhost"
+port = 8080
+debug = TRUE
+ratio = 0.5
+name = hello world
+
+[server.tls]
+enabled = false
+cert = /etc/x.pem
+
+[server]
+port = 9090
+''')
+assert cfg["top"] == 1
+assert cfg["server"]["host"] == "localhost"
+assert cfg["server"]["port"] == 9090          # overwrite via re-opened section
+assert cfg["server"]["debug"] is True
+assert cfg["server"]["ratio"] == 0.5
+assert cfg["server"]["name"] == "hello world"
+assert cfg["server"]["tls"]["enabled"] is False   # merged, not replaced
+assert cfg["server"]["tls"]["cert"] == "/etc/x.pem"
+# quoted numbers stay strings
+c2 = parse_config('[a]\\nx = "123"\\ny = 123')
+assert c2["a"]["x"] == "123" and isinstance(c2["a"]["x"], str)
+assert c2["a"]["y"] == 123
+# first '=' splits
+c3 = parse_config("k = a=b=c")
+assert c3["k"] == "a=b=c"
+assert parse_config("") == {}
+""",
+    },
+    {
+        "name": "rate_limiter_window",
+        "prompt": """Write a Python class:
+
+    class SlidingWindowLimiter:
+        def __init__(self, limit: int, window: float, clock): ...
+        def allow(self, key: str) -> bool: ...
+        def retry_after(self, key: str) -> float: ...
+
+A per-key sliding-window rate limiter.
+
+- `clock` is a zero-argument callable returning float seconds.
+- `allow(key)`: returns True and records the hit if fewer than `limit` hits for that key
+  occurred in the last `window` seconds (strictly: hits with timestamp > now - window).
+  Otherwise returns False and records NOTHING.
+- `retry_after(key)`: seconds until the next call to allow(key) would succeed. Returns
+  0.0 if a call would succeed right now. Otherwise the time until the oldest in-window
+  hit falls out of the window.
+- Keys are independent. Old timestamps must not accumulate without bound.
+
+Return ONLY a fenced python code block containing the class.""",
+        "test": """
+t = {"now": 100.0}
+clk = lambda: t["now"]
+L = SlidingWindowLimiter(3, 10.0, clk)
+assert L.allow("a") is True
+assert L.allow("a") is True
+assert L.allow("a") is True
+assert L.allow("a") is False
+assert L.retry_after("a") == 10.0
+# other key unaffected
+assert L.allow("b") is True
+assert L.retry_after("b") == 0.0
+# denied calls record nothing -> still expires 10s after the 3rd hit
+t["now"] = 109.9
+assert L.allow("a") is False
+t["now"] = 110.1
+assert L.allow("a") is True
+# partial expiry
+t2 = {"now": 0.0}
+clk2 = lambda: t2["now"]
+M = SlidingWindowLimiter(2, 10.0, clk2)
+assert M.allow("k") is True
+t2["now"] = 5.0
+assert M.allow("k") is True
+assert M.allow("k") is False
+assert abs(M.retry_after("k") - 5.0) < 1e-9
+t2["now"] = 10.1
+assert M.allow("k") is True
+""",
+    },
+    {
+        "name": "diff_lcs",
+        "prompt": """Write a Python function:
+
+    def unified_ops(a: list[str], b: list[str]) -> list[tuple[str, str]]:
+
+Compute a minimal edit script transforming list `a` into list `b`, based on a longest
+common subsequence.
+
+Return a list of (op, line) tuples where op is one of:
+  " " (context/unchanged), "-" (delete from a), "+" (insert from b)
+
+The returned sequence, read in order, must:
+  - contain every element of `a` exactly once as either " " or "-"
+  - contain every element of `b` exactly once as either " " or "+"
+  - have the maximum possible number of " " entries (i.e. use an LCS)
+
+When a deletion and an insertion occur at the same position, emit ALL the deletions
+for that run before the insertions.
+
+Return ONLY a fenced python code block containing the function.""",
+        "test": """
+def check(a, b):
+    ops = unified_ops(a, b)
+    assert [l for o,l in ops if o in (" ","-")] == a, (a,b,ops)
+    assert [l for o,l in ops if o in (" ","+")] == b, (a,b,ops)
+    return sum(1 for o,_ in ops if o == " ")
+
+assert unified_ops([], []) == []
+assert unified_ops(["x"], ["x"]) == [(" ","x")]
+assert unified_ops(["x"], []) == [("-","x")]
+assert unified_ops([], ["y"]) == [("+","y")]
+assert check(["a","b","c"], ["a","c"]) == 2
+assert check(["a","b","c"], ["a","x","c"]) == 2
+assert check(["a","b","c","d"], ["b","d"]) == 2
+assert check(list("abcabba"), list("cbabac")) == 4
+assert check(["1","2","3"], ["4","5","6"]) == 0
+# deletions before insertions in a replace run
+ops = unified_ops(["a","b","c"], ["a","x","c"])
+i = [k for k,(o,l) in enumerate(ops) if o=="-"][0]
+j = [k for k,(o,l) in enumerate(ops) if o=="+"][0]
+assert i < j, ops
+""",
+    },
+    {
+        "name": "path_normalize",
+        "prompt": """Write a Python function:
+
+    def resolve(base: str, rel: str) -> str:
+
+Resolve a POSIX-style path `rel` against directory `base`, purely lexically
+(no filesystem access).
+
+- If `rel` is absolute (starts with '/'), it is resolved from '/' and `base` is ignored.
+- Otherwise resolve relative to `base`, which you may assume is an absolute path.
+- Collapse '.' segments, resolve '..' segments, and squeeze repeated '/'.
+- '..' at the root stays at the root ('/..' -> '/').
+- The result must be absolute, must not end in '/' unless it is exactly '/'.
+- An empty `rel` yields the normalized `base`.
+
+Examples:
+    resolve("/a/b", "c")        == "/a/b/c"
+    resolve("/a/b", "../c")     == "/a/c"
+    resolve("/a/b", "/x//y/")   == "/x/y"
+    resolve("/a/b", "")         == "/a/b"
+    resolve("/", "..")          == "/"
+
+Return ONLY a fenced python code block containing the function.""",
+        "test": """
+assert resolve("/a/b", "c") == "/a/b/c"
+assert resolve("/a/b", "../c") == "/a/c"
+assert resolve("/a/b", "/x//y/") == "/x/y"
+assert resolve("/a/b", "") == "/a/b"
+assert resolve("/", "..") == "/"
+assert resolve("/a/b", "../../..") == "/"
+assert resolve("/a/b", "./././c") == "/a/b/c"
+assert resolve("/a//b//", "c/../d") == "/a/b/d"
+assert resolve("/a/b/", "/") == "/"
+assert resolve("/a", "b/c/../../d") == "/a/d"
+assert resolve("//a//b", "c") == "/a/b/c"
+assert resolve("/a/b", "..") == "/a"
+""",
+    },
+    {
+        "name": "retry_backoff",
+        "prompt": """Write a Python function:
+
+    def backoff_schedule(attempts: int, base: float, cap: float,
+                         mode: str = "exponential", factor: float = 2.0) -> list[float]:
+
+Return the list of sleep durations BETWEEN attempts (so len == attempts - 1; an
+`attempts` of 0 or 1 yields []).
+
+- mode "exponential": delay_i = base * (factor ** i) for i = 0, 1, 2, ...
+- mode "linear":      delay_i = base * (i + 1)
+- mode "constant":    delay_i = base
+- Every delay is clamped to at most `cap`.
+- Negative `attempts` yields [].
+- If base < 0 or cap < 0, raise ValueError.
+- If mode is unknown, raise ValueError.
+- Delays are floats.
+
+Return ONLY a fenced python code block containing the function.""",
+        "test": """
+assert backoff_schedule(1, 1.0, 100.0) == []
+assert backoff_schedule(0, 1.0, 100.0) == []
+assert backoff_schedule(-3, 1.0, 100.0) == []
+assert backoff_schedule(4, 1.0, 100.0) == [1.0, 2.0, 4.0]
+assert backoff_schedule(5, 1.0, 3.0) == [1.0, 2.0, 3.0, 3.0]
+assert backoff_schedule(4, 2.0, 100.0, mode="linear") == [2.0, 4.0, 6.0]
+assert backoff_schedule(4, 2.0, 5.0, mode="linear") == [2.0, 4.0, 5.0]
+assert backoff_schedule(3, 1.5, 100.0, mode="constant") == [1.5, 1.5]
+assert backoff_schedule(4, 1.0, 100.0, factor=3.0) == [1.0, 3.0, 9.0]
+try:
+    backoff_schedule(3, -1.0, 10.0); raise AssertionError("expected ValueError")
+except ValueError: pass
+try:
+    backoff_schedule(3, 1.0, -10.0); raise AssertionError("expected ValueError")
+except ValueError: pass
+try:
+    backoff_schedule(3, 1.0, 10.0, mode="nope"); raise AssertionError("expected ValueError")
+except ValueError: pass
+assert all(isinstance(x, float) for x in backoff_schedule(4, 1, 100))
+""",
+    },
+    {
+        "name": "sql_where_builder",
+        "prompt": """Write a Python function:
+
+    def build_where(filters: dict) -> tuple[str, list]:
+
+Build a parameterized SQL WHERE clause from a filter dict. Return (sql, params) where
+`sql` uses '?' placeholders and `params` is the ordered list of bound values.
+
+Keys are column names, optionally suffixed with '__op':
+  - "col"        -> equality:            col = ?
+  - "col__ne"    -> col != ?
+  - "col__gt" / "__gte" / "__lt" / "__lte"  -> the obvious comparisons
+  - "col__in"    -> col IN (?, ?, ...)   (value is a list/tuple)
+  - "col__like"  -> col LIKE ?
+  - "col__isnull" -> value True  -> "col IS NULL"   (no param)
+                     value False -> "col IS NOT NULL" (no param)
+
+Rules:
+- Conditions are joined with " AND " in sorted-by-key order (sort by the full key
+  including suffix) so output is deterministic.
+- A value of None for a plain equality key means "col IS NULL" (no param).
+- An empty list for "__in" produces the always-false condition "1 = 0" (no params).
+- An empty `filters` dict returns ("", []).
+- The returned sql has NO leading "WHERE".
+- An unknown "__op" suffix raises ValueError.
+
+Return ONLY a fenced python code block containing the function.""",
+        "test": """
+assert build_where({}) == ("", [])
+assert build_where({"a": 1}) == ("a = ?", [1])
+assert build_where({"b": 2, "a": 1}) == ("a = ? AND b = ?", [1, 2])
+assert build_where({"a": None}) == ("a IS NULL", [])
+assert build_where({"a__ne": 1}) == ("a != ?", [1])
+assert build_where({"a__gt": 1}) == ("a > ?", [1])
+assert build_where({"a__gte": 1}) == ("a >= ?", [1])
+assert build_where({"a__lt": 1}) == ("a < ?", [1])
+assert build_where({"a__lte": 1}) == ("a <= ?", [1])
+assert build_where({"a__in": [1,2,3]}) == ("a IN (?, ?, ?)", [1,2,3])
+assert build_where({"a__in": []}) == ("1 = 0", [])
+assert build_where({"a__like": "x%"}) == ("a LIKE ?", ["x%"])
+assert build_where({"a__isnull": True}) == ("a IS NULL", [])
+assert build_where({"a__isnull": False}) == ("a IS NOT NULL", [])
+s, p = build_where({"z": 1, "a__in": [7,8], "m__isnull": True})
+assert s == "a IN (?, ?) AND m IS NULL AND z = ?", s
+assert p == [7, 8, 1], p
+try:
+    build_where({"a__bogus": 1}); raise AssertionError("expected ValueError")
+except ValueError: pass
+""",
+    },
+]

--- a/dot/omlx/speculative-decoding-findings.md
+++ b/dot/omlx/speculative-decoding-findings.md
@@ -6,6 +6,13 @@ machines and it was a net *loss* on both (moria 0.97×, dungeon 0.91×). The tec
 that wins big on a bandwidth-starved discrete GPU does not transfer to MLX here. This
 doc exists so we don't re-try it without new reason.**
 
+> **2026-08-15 update — the "when it *would* help" boundary below was hit, and the
+> prediction held.** `Qwen3.8-27B` is a *dense* 27B with published MTP drafters, and there
+> speculative decoding is a real win: **1.43× on code, 1.19× average** (see
+> `docs/local-llm-benchmarks.md`). The MoE reasoning in this doc is still correct — it just doesn't
+> apply to dense targets. Caveat: oMLX 0.5.7's `vlm_mtp` measured **not bit-identical** on
+> that pair against a verified determinism control, so it is documented but left disabled.
+
 Date: 2026-06-12. oMLX 0.4.4rc1. Tested by: Greg + Claude.
 
 ---

--- a/dot/pi/.pi/agent/models.json.tpl
+++ b/dot/pi/.pi/agent/models.json.tpl
@@ -18,16 +18,16 @@
           "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
         },
         {
-          "id": "Qwen3.6-35B-A3B-8bit",
-          "name": "Qwen 3.6 35B A3B 8-bit (thinking, 262k ctx, 81k max, heavy)",
+          "id": "Qwen3.6-35B-A3B-4bit-DWQ",
+          "name": "Qwen 3.6 35B A3B 4-bit DWQ (MoE, 104 t/s, quality-leaning)",
           "contextWindow": 262144,
           "maxTokens": 81920,
           "input": ["text", "image"],
           "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
         },
         {
-          "id": "Qwen3.6-35B-A3B-6bit",
-          "name": "Qwen 3.6 35B A3B 6-bit (thinking, 262k ctx, balanced)",
+          "id": "Qwen3.6-35B-A3B-8bit",
+          "name": "Qwen 3.6 35B A3B 8-bit (thinking, 262k ctx, 81k max, heavy)",
           "contextWindow": 262144,
           "maxTokens": 81920,
           "input": ["text", "image"],

--- a/dot/pi/.pi/agent/models.json.tpl
+++ b/dot/pi/.pi/agent/models.json.tpl
@@ -10,8 +10,16 @@
       },
       "models": [
         {
+          "id": "Qwen3.6-35B-A3B-4bit",
+          "name": "Qwen 3.6 35B A3B 4-bit (MoE, 131 t/s, coding DEFAULT)",
+          "contextWindow": 262144,
+          "maxTokens": 81920,
+          "input": ["text", "image"],
+          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
           "id": "Qwen3.6-35B-A3B-8bit",
-          "name": "Qwen 3.6 35B A3B (thinking, 262k ctx, 81k max, heavy)",
+          "name": "Qwen 3.6 35B A3B 8-bit (thinking, 262k ctx, 81k max, heavy)",
           "contextWindow": 262144,
           "maxTokens": 81920,
           "input": ["text", "image"],
@@ -26,16 +34,8 @@
           "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
         },
         {
-          "id": "Qwen3.6-27B-8bit",
-          "name": "Qwen 3.6 27B 8-bit (thinking, 262k ctx, balanced)",
-          "contextWindow": 262144,
-          "maxTokens": 81920,
-          "input": ["text", "image"],
-          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
-        },
-        {
-          "id": "Qwen3.6-27B-4bit",
-          "name": "Qwen 3.6 27B 4-bit (thinking, 262k ctx, fast)",
+          "id": "Qwen3.8-27B-4bit",
+          "name": "Qwen 3.8 27B 4-bit (dense, 23 t/s, slow specialist)",
           "contextWindow": 262144,
           "maxTokens": 81920,
           "input": ["text", "image"],


### PR DESCRIPTION
## Why

Qwen3.8-27B dropped on 2026-08-14. The question was which quantization to run locally on
moria (M4 Max, 128 GB) — and, once that was settled, whether it should actually replace the
MoE we already had. Both answers turned out to be counterintuitive.

Everything below is measured on this machine, not inferred. The full write-up is
[`docs/local-llm-benchmarks.md`](docs/local-llm-benchmarks.md); the reproducible harness is
in [`dot/omlx/bench/`](dot/omlx/bench/).

## What we're keeping, and what we'll use it for

| model | role | why |
|---|---|---|
| **`Qwen3.6-35B-A3B-4bit`** (MoE, ~19 GB) | **default coding model** | 130.7 t/s decode, 9/10 on the coding eval, whole suite in 17.4 min. Fastest thing we have that is also accurate. |
| **`Qwen3.8-27B-4bit`** (dense, 14.95 GiB) | **specialist** | Newer generation, and 2.6× more token-efficient (31.8k vs 84.1k tokens to solve the same eval). Reach for it when A3B has actually failed a hard problem, or when output tokens are precious. |
| `Qwen3.6-35B-A3B-8bit` (35 GB) | kept, demoted | Target of the nix-managed `-long-context` symlink, and our 8-bit reference point. Superseded for general use. |
| `gemma-4-26b-a4b-it-qat-4bit`, `gemma-4-e4b-it-qat-4bit` | unchanged | summarization / roger vault index |
| `gpt-oss-120b-heretic-*` | unchanged | roger's digest job depends on it |

## The headline result

| model | decode t/s | coding eval | tokens | wall-clock |
|---|---|---|---|---|
| **Qwen3.6-35B-A3B-4bit** | **130.73** | **9/10** | 84,062 | **17.4 min** |
| Qwen3.6-35B-A3B-4bit-DWQ | 103.64 | 10/10 | 87,777 | 19.1 min |
| Qwen3.8-27B-4bit (`medium`) | 22.96 | 8/10 | 31,849 | 27.1 min |

The MoE is **5.7× faster and was not worse.** That is not a trade-off, so it becomes the
default.

**Important honesty caveat, reflected in the config comments:** 9-vs-8 on ten tasks is one
task — noise, not a demonstrated quality difference — and both sit near the eval's ceiling,
which is exactly when a benchmark stops discriminating. The claim is *"the MoE was not
worse"*, not *"the MoE is better"*. The 5.7× speed gap **is** real.

## Models we considered and rejected

- **`Qwen3.8-27B-8bit` / `Qwen3.6-27B-8bit`** — 8-bit costs ~2× the decode speed on a *dense*
  27B (23.0 → 11.9 t/s) because every parameter is re-read each step. Quality evidence at
  ≥4 bits is that the difference is undetectable. **Deleted.**
- **6-bit** — does not exist upstream for either model. Self-quantizing would also strand us
  from the published MTP drafters, whose precision must match the target.
- **`Qwen3.6-27B-4bit`** — architecturally *identical* to Qwen3.8-27B: same `model_type`,
  same vocab, same layer counts, identically-sized 14.95 GiB weights, same measured speed.
  Qwen3.8 is a retrain on the same skeleton, so this was strictly superseded. **Deleted.**
- **`Qwen3.6-35B-A3B-8bit` as the daily driver** — 86.9 t/s vs 130.7 at 4-bit, for 35 GB
  instead of 19 GB. Note the MoE 8-bit penalty (1.50×) is genuinely smaller than the dense
  one (1.92–2.00×), because a MoE only reads its ~3B active params — but it is *not* free,
  which is the part that's easy to get wrong.
- **mlx-dspark** — better speculative *ratios* (1.55× code) but from a ~16 t/s baseline vs
  oMLX's ~23, so its accelerated 24.9 t/s still loses to oMLX+MTP's 32.9, and it means running
  a second server. **Not adopted.** The 2.5 GB drafter was deleted.

~73 GB reclaimed in total.

## Two settings changes that matter more than the model choice

**`reasoning_effort` (new in Qwen3.8) defaults to `xhigh`, and `xhigh` is unusable.**
Unconfigured, it burned 8,000 tokens over 401 s and *never produced an answer*
(`finish_reason: length`). And giving it *more* thinking did not help — it scored lower:

| config | eval | tokens | wall |
|---|---|---|---|
| `medium` | **8/10** | 31,849 | 27.1 min |
| `xhigh` | 6/10 | 123,418 | 111.5 min |

Every extra failure was a truncation rather than a wrong answer. Two tasks on a 10-task
suite is suggestive rather than proven — but pinning `medium` needs only the unambiguous
result, which is that unset/`xhigh` **never terminates at all**. Shipped with an 8192-token
thinking budget as a hard stop.

**Speculative decoding finally pays off on a dense model — but oMLX's implementation is not
lossless.** This is the re-test `speculative-decoding-findings.md` explicitly asked for, and
its prediction held: the earlier 0.97× loss was on a low-active-param MoE; on a dense 27B the
MTP drafter gives **1.43× on code**. But greedy verification is supposed to be *bit-identical*,
and it isn't:

| run | result |
|---|---|
| control — drafter OFF, captured twice across a restart | **3/3 identical** |
| drafter OFF vs ON | **1/3 identical, 2 diverged** |

The control shows the server is deterministic at temp 0 — reproducing identical hashes even
across a restart — so the divergence is consistent with a real effect of the drafter rather
than nondeterminism. With n=3 that is strong evidence, not proof. **Left disabled** — a speedup that silently changes output isn't
the trade the technique advertises. Looks like an oMLX 0.5.7 bug; `bench/lossless_check.py`
re-checks it in ~3 minutes after any upgrade.

## Methodology, and why it needed to be this careful

Seven separate confounds produced plausible-but-wrong numbers during this work. Three
required permanent tooling (the third, prefix-cache contamination, is covered under
Corrections below):

1. **Foreign traffic on the shared server.** roger's digest job (normally 05:30, fired late as
   a launchd wake catch-up) hammered `gpt-oss-120b` on the same oMLX instance for ~5 minutes,
   overlapping exactly one model's window and depressing it ~20%. Nothing in the benchmark
   output hinted at it. `bench/contention_audit.sh` now certifies a window against the server
   log — and **fails closed**, after the first version of it turned out to fail open.
2. **Engine-pool residency.** oMLX keeps every model it has served resident. With 4 models /
   69 GB loaded, Qwen3.8-27B-4bit measured **32% slower** than Qwen3.6-27B-4bit — which would
   have been written up as a real regression. Measured alone they are within 4.4%, as
   identically-sized weights on an identical architecture predict. Every measured model now
   gets a freshly restarted server.

Also worth knowing: streaming chunk counts are **not** token counts (that bug produced a
nonsensical "7 t/s decode" against a 22 t/s end-to-end rate); truncation is not the same as
failure (one run hit the cap and still passed, because the code block landed before the
cutoff); and macOS has no `timeout`, which silently *skipped* a whole benchmark phase rather
than running it.

Drift control: each pass re-measures its first model last. Across the full matrix that came
out at **−3.9%** — an order of magnitude too small to manufacture the 2× quant gap.

## What each benchmark measures, and how to read it

`docs/local-llm-benchmarks.md` defines all nine metrics in full. The short version, because
several of them are easy to misread:

| metric | how it's computed | reading it |
|---|---|---|
| **Decode tok/s** | `completion_tokens / (wall − TTFT)`; median of 3 per family, mean of the 3 family medians | Higher better. <20 feels sluggish, >80 feels instant. Ratios are far more trustworthy than absolutes on a live desktop. |
| **TTFT** | wall time to first streamed token | Lower better. This is the pause you actually feel. |
| **Prefill tok/s** | `longctx.py`: thinking off, output capped at 24 tokens so wall ≈ prefill | Higher better — but watch the *shape*. Flat/linear is good; collapsing means quadratic attention cost. |
| **Coding eval x/10** | model emits a fenced block, we `exec` it and run assertions it never saw; pass = all hold | Higher better, **but n=10 means a 1-task gap is noise.** Establishes "not worse", never "better". |
| **Truncations** | count of `finish_reason: length` | Lower better. A truncation is a *config* failure, not a capability failure — don't conflate them. |
| **Tokens / wall-clock** | totals across the suite | Lower better, and only meaningful alongside pass rate. Wall-clock is the most honest headline number: it combines speed *and* verbosity. |
| **Draft acceptance** | oMLX `vlm_mtp stats` | Higher better, but does **not** predict speedup alone — rejected tokens are wasted verify compute. |
| **Losslessness** | SHA-256 of output, optimization off vs on, **plus an off-vs-off control** | Must be identical. The control is not optional: without it you can't tell divergence from nondeterminism. |
| **Quant penalty** | 4-bit t/s ÷ 8-bit t/s | Lower better. Near the weight-byte ratio ⇒ purely bandwidth-bound (dense). Smaller ⇒ active-params story (MoE). Never zero. |

## Corrections since the first commit

A review pass found four blocking harness defects and one measurement that was wrong. Both
commits are in this PR; the second fixes them.

**The long-context numbers were measuring oMLX's prefix cache, not prefill.** Every prompt was
a strict prefix-extension of the previous one and sizes ran in ascending order. The tell was
unmistakable once pointed at: **a 7,862-token prompt returned faster in wall-clock than a
1,946-token one.** Fixed with a per-prompt random nonce, shuffled sizes, a warm-up, and an
explicit `cached_tokens == 0` assertion. Re-measured:

| prompt | A3B (corrected) | dense (corrected) | speedup | dense, as previously published |
|---|---|---|---|---|
| ~2K | 1.97 s | 14.64 s | 7.4× | — |
| ~16K | 10.71 s | 107.57 s | **10.0×** | — |
| ~64K | 77.2 s | **508.1 s** | 6.6× | 290.6 s (1.75× too fast) |

Notably this *strengthens* the conclusion: prefill speedup is 6.6–10.0×, genuinely wider than
the 5.7× decode gap, which the contaminated data had understated. A 64K context costs the
dense model **8.5 minutes to first token**.

**`contention_audit.sh` failed open.** It parsed the wrong awk field, so `START`/`END` came
back empty, every log line fell outside the window, and it printed `CLEAN`. For the one tool
whose entire job is catching contamination, a false CLEAN is the worst possible failure — it
launders a bad run as verified. It now fails closed and matches the model id exactly.
Regression-tested against the known-contaminated window: it correctly reports **8 of 18
requests foreign** where the old version said CLEAN.

**`bench/omlx_key` was not gitignored.** The documented setup told you to write a plaintext
API key into a git-tracked directory. Now gitignored, with `$OMLX_API_KEY` preferred and a
graceful hint instead of a `FileNotFoundError` at import.

Also fixed: a `KeyError` that destroyed the summary of a up-to-111-minute run if one request
failed; `bench/` being stowed into `$HOME`; a silent chunk-count fallback in `bench.py` (the
exact bug the docs warn about); and an extractor that concatenated *every* fenced block,
manufacturing failures for verbose models.

Wording was tightened to match the evidence — "strictly worse" and "conclusive" both outran
what n=1 and n=3 support. The 9-vs-8 caveat is now applied consistently to `medium`-vs-`xhigh`
and to DWQ's 10-vs-9.

## Settings research — the "free win" pass

We went looking for settings or checkpoints that would improve quality or speed at no cost.
Most candidates did not survive contact with the numbers.

- **Sampling was already right.** Qwen publishes *different* parameters per task type. Our
  temp 0.6 / presence_penalty 0.0 is exactly the official **"thinking, precise coding"** row.
  The general-task row (temp 1.0, presence_penalty **1.5**) is explicitly not what you want
  for code — the card warns higher presence_penalty "may occasionally result in language
  mixing and a slight decrease in model performance". Added `min_p: 0.0` to match.
- **DWQ is real but not free.** `Qwen3.6-35B-A3B-4bit-DWQ` scored **10/10** — best of anything
  tested, and the only model to pass `diff_lcs` — but runs at **103.6 vs 130.7 tok/s (21%
  slower)**, because DWQ keeps embeddings, `lm_head`, routers and shared experts at higher
  precision and a MoE reads those every token. One extra task is not a demonstrated gain by
  our own n=10 standard, while 21% is measured and certain. **Registered and documented as
  the quality-leaning alternative; not made default.**
- **OptiQ rejected on its own numbers.** Its higher aggregate "Capability Score" hides a
  per-metric table where it **loses** MMLU (−0.9), GSM8K (−1.5), IFEval (−0.4) and **ties
  HumanEval (+0.0)** — the aggregate is carried by HashHop (+8.0). Nothing for coding, at
  24.7 GB vs 19 GB.
- **TurboQuant KV cache rejected** — a known ~8× *slowdown* at 4/6-bit; only 8-bit helps, and
  the toggle has been disabled at times pending a prefill-path fix.


## Changes

- `docs/local-llm-benchmarks.md` — full write-up: hardware, test parameters, every results
  table, and the confounds section.
- `dot/omlx/bench/` — reproducible harness (throughput, coding eval + 10 original tasks with
  executable tests, reasoning-effort study, long-context prefill, losslessness check,
  contention audit).
- `dot/omlx/.omlx/model_settings.json` — A3B-4bit added as default; Qwen3.8-27B-4bit
  documented as specialist with `reasoning_effort: medium`; A3B-8bit marked superseded.
- `dot/pi/.pi/agent/models.json.tpl` — A3B-4bit registered, Qwen3.8-27B-4bit relabelled,
  deleted Qwen3.6-27B entries removed.
- `dot/omlx/CLAUDE.md` — "which coding model to use" guidance.
- `dot/omlx/speculative-decoding-findings.md` — cross-reference noting its prediction held.
- `dot/omlx/bench/README.md` — setup, exact reproduction commands, and the measurement
  protocol, so the harness is runnable from a clean clone.
- `dot/omlx/.gitignore` / `.stow-local-ignore` — keep the API key out of git and `bench/` out
  of `$HOME`.

## Verification

- `model_settings.json` and `models.json.tpl` re-validated as JSON; `just secrets` regenerated
  `models.json`; `pi --list-models` confirms both models resolve at 262.1K context.
- End-to-end request against the shipped config returns `finish_reason: stop` with reasoning
  correctly split into `reasoning_content` — the behaviour the `xhigh` default failed to
  produce.
- No dangling references to the removed `dot/omlx/qwen3.8-findings.md`.
- `contention_audit.sh` regression-tested three ways: certifies a known-clean window, catches
  the known-contaminated one (8/18 foreign), and hard-exits on a malformed window.
- Harness verified to run from `$OMLX_API_KEY` with no key file present, and to exit with a
  readable hint when neither is available.
- Every long-context row re-verified `cached_tokens == 0`.

Note: `just secrets` could not be re-run here (1Password desktop integration needs an
interactive unlock), so the gitignored generated `models.json` was updated directly from the
template with the existing secret preserved. Re-run `just secrets` at your convenience — the
tracked `.tpl` is the source of truth and is correct.

## Not tested

Vision (both models are VLMs; only text was sent), and quantization quality directly — ten
tasks cannot resolve that, so the 4-bit-is-fine claim rests on published work rather than ours.
