### PR TITLE
feat(dungeon): alert when Frigate's GenAI descriptions go silently down

### DIFF
--- a/nixos/hosts/macs/dungeon/default.nix
+++ b/nixos/hosts/macs/dungeon/default.nix
@@ -263,6 +263,35 @@ in {
     };
   };
 
+  # Detect Frigate's GenAI descriptions being silently down.
+  #
+  # This is invisible to every monitoring layer we have: object detection is unaffected
+  # (yolov9-t runs on the ANE), no container restarts, no HTTP probe moves, no cAdvisor
+  # metric changes. Frigate looks perfectly healthy while writing no descriptions.
+  # home-lab/docs/runbooks/frigate-genai-down.md said to build this "if it recurs" — it
+  # recurred on 2026-08-16, when a `brew upgrade` left oMLX running a deleted bundle and
+  # every GenAI request 409'd on a cached model-load failure. It was found days later by
+  # accident, reading an unrelated log.
+  #
+  # One real vision round-trip through oMLX; Pushover on two consecutive failures.
+  # Read-only by design — it never restarts oMLX, because an auto-heal would mask exactly
+  # the recurring upgrade bug it exists to surface.
+  launchd.user.agents.frigate-genai-check = {
+    serviceConfig = {
+      ProgramArguments = [
+        "/bin/bash"
+        "/Users/${vars.user.name}/Git/home-lab/scripts/frigate-genai-check.sh"
+      ];
+      RunAtLoad = true;
+      # Every 30 min. Far looser than port-sync-check's 15 min: a missing description is
+      # not urgent, and each run costs a real VLM inference that competes with Frigate's
+      # own GenAI calls for the same ~28GB Metal ceiling.
+      StartInterval = 1800;
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/frigate-genai-check.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/frigate-genai-check.log";
+    };
+  };
+
   # Detect & auto-heal a gluetun tunnel that is broken while Docker insists it is healthy.
   #
   # Incident 2026-08-14: a mains blip took the WAN down; gluetun rode it out by cycling


### PR DESCRIPTION
## What I found

Investigating `ModuleNotFoundError: No module named 'transformers.models.qwen3_vl'` on dungeon: **the model itself is fine.** `Qwen3-VL-4B-Instruct` loads and serves vision correctly — verified with a real round-trip (it identified a test image as "Red"). The failure was transient and had already cleared on a later restart.

Root cause was the failure mode `docs/runbooks/frigate-genai-down.md` calls **Fix B**: `brew upgrade` replaced the oMLX bundle at 21:33 the night before, the old process kept running against its now-deleted site-packages, and oMLX then **cached** the load failure so every later request short-circuited to 409 without retrying.

Scope worth being precise about: **object detection was never affected** — that is yolov9-t on the ANE via the `frigate-detector` agent. Only Frigate's GenAI review/object *descriptions* were down.

## Why this needs an agent

Nothing could see it. No container restarted, no HTTP probe moved, no cAdvisor metric changed. Frigate looked perfectly healthy while writing no descriptions, and it was found **days later, by accident**, reading an unrelated log.

The runbook already anticipated this and specified the remedy conditionally:

> **Nothing alerts on this.** … If it recurs, the fix is a `scripts/frigate-genai-check.sh` in the mould of `scripts/port-sync-check.sh`: one real vision round-trip through oMLX on a launchd timer, Pushover on failure.

It recurred, so this builds it.

## Design choices

- **A real vision round-trip, not a text prompt.** A text-only probe passes against a VLM whose vision tower failed — that check would be worse than useless. It sends a 1×1 synthetic PNG, so it needs no camera to have tripped and no snapshot on disk.
- **Reads the model id from `frigate/config.yml`,** so the check cannot drift from what Frigate actually asks for. That drift is itself one of the documented failure modes.
- **Read-only — it never restarts oMLX.** An auto-heal would silently paper over the recurring post-upgrade bug this exists to surface, and bouncing a busy inference server to fix a description feature is a bad trade. The runbook's Fix B is two commands.
- **Classifies rather than just saying "down":**

| probe result | meaning |
|---|---|
| `HTTP_409` | oMLX cached a load failure → Fix B, restart oMLX first |
| `NOT_SERVED` | model id drift, or model deleted |
| `AUTH_401`/`AUTH_403` | oMLX is **up**; the key is wrong — different subsystem |
| `UNREACHABLE` | oMLX not answering on :8000 |
| `EMPTY_RESPONSE` | loaded, but returned nothing for a vision prompt |

  The AUTH split is deliberate: an earlier version reported a 401 as "UNREACHABLE … check the launchd agent", pointing at the wrong subsystem. roger's digest had just cost real time to exactly that confusion.

Follows existing check conventions — Pushover clamped to priority 0, stands down during a mains outage, two-run streak before alerting, 6h re-alert cooldown, secrets parsed (not sourced) from `secrets/.env`.

## Verification

Every branch exercised on dungeon:

| case | result |
|---|---|
| healthy | `genai ok (Qwen3-VL-4B-Instruct) — OK 'Red'` |
| model not served | detected + classified `NOT_SERVED` |
| oMLX unreachable | detected + classified `UNREACHABLE` |
| bad API key | detected + classified `AUTH_401` |
| first failure | silent (below streak) ✅ |
| second failure | alerts ✅ |
| recovery | streak cleared ✅ |

`nix build .#darwinConfigurations.dungeon.system --dry-run` clean, with `org.nixos.frigate-genai-check.plist` in the derivation.

## Interval

30 min rather than `port-sync-check`'s 15: a missing description is not urgent, and each run costs a real VLM inference competing with Frigate's own GenAI calls for the same ~28 GB Metal ceiling.

Paired with home-lab `a2aed13`, which adds the script and updates the runbook's Prevention section.