### PR TITLE
fix(nixos): make the declarative git hooks actually run

### DIFF
--- a/nixos/CLAUDE.md
+++ b/nixos/CLAUDE.md
@@ -499,6 +499,38 @@ bash -n /tmp/pa.sh   # syntax check
 *user* agent instead — see `launchd.user.agents.home-lab-sync` in `hosts/macs/dungeon` and
 `bin/home-lab-sync.sh`.
 
+## Git hooks do not run in a `git worktree` — silently
+
+`nix develop` installs the hooks in `flake-modules/dev.nix` (treefmt on commit,
+`nix flake check` on push). **They do not fire in a worktree**, and nothing says so:
+the commit simply succeeds with no hook output at all. Not "the hook failed" — the
+hook was never found.
+
+Cause is upstream, in git-hooks.nix's installation script:
+
+```bash
+common_dir=$(git rev-parse --path-format=absolute --git-common-dir)
+common_dir=${common_dir#$GIT_WC/}                    # deliberately made relative
+git config --local core.hooksPath "$common_dir/hooks"
+```
+
+It goes out of its way to make the path **relative** (`.git/hooks`), and
+`core.hooksPath` is `--local`, which worktrees *share*. In a worktree `.git` is a
+file, not a directory, so `.git/hooks` resolves to nothing.
+
+`git config --local --unset core.hooksPath` fixes it — git then falls back to
+`$GIT_COMMON_DIR/hooks`, which resolves correctly from both — but it does not stick,
+because the next `nix develop` writes it straight back.
+
+To actually run a hook from a worktree, override it for the one command:
+
+```bash
+git -c core.hooksPath="$(git rev-parse --path-format=absolute --git-common-dir)/hooks" push
+```
+
+So: **do not treat a clean commit in a worktree as evidence it passes the hooks.**
+Verify from the main checkout, or with the override above.
+
 ## Dev Container Validation
 
 A Docker dev container is available for validating configs without a NixOS host:

--- a/nixos/flake-modules/dev.nix
+++ b/nixos/flake-modules/dev.nix
@@ -10,18 +10,79 @@
     config,
     pkgs,
     ...
-  }: {
+  }: let
+    # This flake lives in nixos/, but git's root — and so pre-commit's working
+    # directory — is the toolbox repo root one level up. Nothing bridges that gap
+    # for us, and until these wrappers existed neither hook could run at all:
+    #
+    #   * `nix flake check` from the repo root finds no flake there.
+    #   * treefmt's wrapper hardcodes `--tree-root-file=flake.nix` and gives up with
+    #     "could not find [flake.nix] in /Users/…/toolbox".
+    #
+    # Both failed on every commit and every push. It went unnoticed because the
+    # hooks are only installed by entering the dev shell, and the repo still had
+    # working hand-written ones left over from the deleted scripts/install-hooks.sh
+    # sitting in .git/hooks — so anyone who never ran `nix develop` saw no problem,
+    # and anyone who did had their working hooks replaced by broken ones.
+    #
+    # `gitBin`, not `git`: a `let` binding outranks `with pkgs;`, so naming this
+    # `git` would silently turn the `git` in the devShell's package list below into
+    # this string, and mkShell would try to source the binary as a setup hook.
+    gitBin = "${pkgs.git}/bin/git";
+
+    # pre-commit passes filenames relative to the git root, so make them absolute
+    # BEFORE changing directory — otherwise they resolve against nixos/ and treefmt
+    # is handed paths that do not exist.
+    treefmtHook = pkgs.writeShellScript "treefmt-hook" ''
+      set -euo pipefail
+      root=$(${gitBin} rev-parse --show-toplevel)
+      files=()
+      for f in "$@"; do files+=("$root/$f"); done
+      cd "$root/nixos"
+      exec ${config.treefmt.build.wrapper}/bin/treefmt \
+        --fail-on-change --no-cache "''${files[@]}"
+    '';
+
+    # `nix` is put on PATH by /etc/zshrc and /etc/bashrc, which a GUI git client
+    # (VS Code's SCM pane, Fork, Tower) never sources — so a bare `nix` here dies
+    # with "command not found" from anything that isn't a terminal.
+    #
+    # The profile path rather than `${pkgs.nix}/bin/nix`: these Macs run Determinate
+    # Nix with nix-darwin's `nix.enable = false`, so pinning nixpkgs' nix would run a
+    # client the daemon does not match. It is also the stable-path rule from
+    # dot/README.md — /nix/var/nix/profiles/... survives a GC, a store path may not.
+    flakeCheckHook = pkgs.writeShellScript "flake-check-hook" ''
+      set -euo pipefail
+      export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+      cd "$(${gitBin} rev-parse --show-toplevel)/nixos"
+      exec nix flake check
+    '';
+  in {
     pre-commit.settings.hooks = {
       treefmt = {
+        # No `package`: upstream reads it only to build the default `entry`, which
+        # the line below replaces, so setting it would imply a control it no longer
+        # has — and the wrapper reaches for the same derivation directly.
         enable = true;
-        package = config.treefmt.build.wrapper;
+        entry = "${treefmtHook}";
+        # Only the files the formatters actually handle. Left unset (the default),
+        # pre-commit hands treefmt *every* staged file — README.md, .github/*.yml,
+        # dot/… — each one outside the tree root treefmt is about to establish.
+        #
+        # `.nix` because treefmt.nix enables only alejandra, statix and deadnix. Add
+        # a formatter for another filetype there and widen this too, or the hook
+        # quietly stops covering it (`nix flake check` still would).
+        files = "^nixos/.*\\.nix$";
       };
 
       flake-check = {
         enable = true;
         name = "nix flake check";
-        entry = "nix flake check";
+        entry = "${flakeCheckHook}";
         pass_filenames = false;
+        # A push that only touches dot/ or bin/ cannot break the flake, and this
+        # check is minutes, not seconds.
+        files = "^nixos/";
         stages = ["pre-push"];
       };
     };


### PR DESCRIPTION
## Why

Neither declarative git hook has ever worked.

```
$ git commit
treefmt..................................................................Failed
- hook id: treefmt
- exit code: 1

Error: failed to load config: failed to determine tree root:
  could not find [flake.nix] in /Users/ghilston/Git/toolbox
```

Both hooks fail for the same structural reason: this flake lives in `nixos/`, but git's root — and therefore pre-commit's working directory — is the toolbox repo root one level up. treefmt's wrapper hardcodes `--tree-root-file=flake.nix` and looks for it at the repo root. The pre-push hook's entry is the literal string `nix flake check`, run from that same root, where there is no flake at all.

So `nix develop` installed a pair of hooks that rejected every commit and every push.

**Why nobody noticed.** Entering the dev shell is the only thing that installs them, and `.git/hooks` still held working hand-written hooks left over from the `scripts/install-hooks.sh` that `321ed35` deleted. Anyone who never ran `nix develop` saw nothing wrong. Anyone who did had their working hooks replaced by broken ones — and pre-commit's *migration mode* kept the old ones running underneath, so even the symptom was muddled: `nix fmt` output appeared first, then a treefmt failure.

## What changed

**Each hook runs through a wrapper that resolves the repo root and works from `nixos/`.** For treefmt the filenames must be made absolute *before* the directory change — pre-commit passes them relative to the repo root, so after `cd nixos` they would name paths that do not exist.

**Both hooks are scoped with `files`, which was unset:**

| hook | was | now |
|---|---|---|
| `treefmt` | every staged file — `README.md`, `.github/*.yml`, `dot/…` — each outside the tree root it was about to establish | `^nixos/.*\.nix$`, what the three formatters actually handle |
| `flake-check` | every push | `^nixos/`, since a push that only moves `dot/` or `bin/` cannot break the flake, and the check is minutes |

**Deliberately *not* touching `.gitignore`.** `.pre-commit-config.yaml` does need ignoring — git-hooks.nix writes it at the repo root as a GC-root symlink into the store and regenerates it on every dev-shell entry. But `feat/backup-tier1-agent` already carries exactly that change in `2e498c9`. Adding it here too would append to the same place in the same file and hand whichever PR merges second a conflict over a one-line agreement, so this PR is `dev.nix` only.

One thing worth pointing at, since it cost a debugging cycle: the wrapper binds `gitBin`, not `git`. A `let` binding outranks `with pkgs;`, so naming it `git` silently turns the `git` in the dev shell's package list into that string, and mkShell tries to source the binary as a setup hook:

```
setup: line 855: source: /nix/store/…-git-2.54.0/bin/git: cannot execute binary file
```

## Verification — by running them, not reading them

**pre-commit, misformatted input rejected:**

```
$ printf '{\n  foo   =    1;\n}\n' > nixos/modules/scratch-fmt-test.nix && git commit
treefmt..................................................................Failed
ERRO file has changed path=modules/scratch-fmt-test.nix
Error: unexpected changes detected, --fail-on-change is enabled
```

Note `path=modules/scratch-fmt-test.nix` — relative to the `nixos/` tree root, which is the fix working.

**pre-commit, formatted input accepted:** `treefmt...Passed`.

**pre-push:** `nix flake check..........................................................Passed`

Also `nix fmt` clean, `nix eval` on moria clean, and the treefmt flake check builds.

## From review

Three things folded in after the review pass:

**`nix` is resolved, not assumed.** `flakeCheckHook` had a bare `nix`, two lines under a comment explaining why `git` is resolved to a store path. `nix` reaches the PATH via `/etc/zshrc` and `/etc/bashrc`, which a GUI git client (VS Code's SCM pane, Fork, Tower) never sources — so the hook would have died with `nix: command not found` from anything that is not a terminal. It now prepends `/nix/var/nix/profiles/default/bin`, rather than pinning `${pkgs.nix}/bin/nix`: these Macs run Determinate Nix with `nix.enable = false`, so a nixpkgs client would not match the daemon, and `dot/README.md`'s stable-path rule says a profile path over a store path anyway. **Verified by stripping `nix` out of PATH entirely and pushing** — `nix flake check..........Passed`.

**`package =` dropped.** Upstream reads it for exactly one thing, building the default `entry`, which this PR replaces — so it was dead config implying a control it no longer had, and a second spelling of a derivation the wrapper already names directly.

**The worktree trap is documented** (`nixos/CLAUDE.md`). git-hooks.nix writes a *relative* `core.hooksPath = .git/hooks`, and `core.hooksPath` is `--local`, which worktrees share — but `.git` is a *file* in a worktree, so it resolves to nothing and **no hook runs, with no output at all**. That is the same silent-skip class this PR exists to kill, one level up, so it should not stay tribal knowledge. Out of scope to fix here (it means patching upstream), and the obvious local workaround — `git config --local --unset core.hooksPath` — does not stick, because the next `nix develop` writes it back.

## Also verified after those changes

- **Mixed staging.** A misformatted `nixos/modules/scratch.nix` staged alongside `docs/scratch-note.md`: `traversed 1 files`, commit rejected, and the `.md` left byte-identical — `files` filters before the wrapper ever sees it.
- Formatted commit passes; `nix flake check` passes on push.

All of the above was exercised in a throwaway clone, not a worktree, for the reason documented above.

## Risk

Low, and confined to git hooks — one file, no host configuration, no CI, no flake outputs beyond `devShells.default`'s `shellHook`.

The one real behaviour change for you: pushes touching `nixos/` now actually run `nix flake check`, which takes minutes. That is what `dev.nix` has always claimed to do; it simply never did. If that turns out to be too slow in practice, moving it to `stages = ["manual"]` or dropping the hook is a one-line follow-up.

Note the hooks currently installed in your `.git/hooks` are already the fixed ones — I installed them while testing. The `.legacy` copies pre-commit's migration mode preserved are still there and still run first, which is harmless but duplicates `nix fmt`; `rm .git/hooks/*.legacy` retires them.
