### PR TITLE
feat(dungeon): restic + the backup-tier1 launchd agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ nixos/.envrc
 
 # generated secrets (use secrets/.env.tpl as template, run `just secrets`)
 nixos/secrets/.env
+
+# Written by the git-hooks flake module whenever a nix command evaluates the flake.
+# It is a symlink into /nix/store, so committing it pins a path that exists on exactly
+# one machine — and a `git add -A` sweeps it up silently.
+.pre-commit-config.yaml

--- a/nixos/docs/darwin-post-deploy.md
+++ b/nixos/docs/darwin-post-deploy.md
@@ -37,6 +37,27 @@ Apple-Silicon object detector that Frigate connects to over ZMQ. It is not auto-
 - [ ] Re-run `darwin-rebuild switch` so the agent finds the venv, then verify:
       `tail ~/Library/Logs/frigate-detector.log` shows "ZMQ server successfully bound to tcp://*:5555"
 
+## Tier-1 Backup (dungeon only)
+The `backup-tier1` launchd agent (hosts/macs/dungeon/default.nix) runs the home-lab script at
+03:30 into two restic repositories. `restic` itself comes from homebrew-server.nix, but three
+things cannot be expressed in nix and the agent fails — loudly, nightly — without them:
+- [ ] Create the `Infra/restic` item in 1Password with a **strong, unique** repository password,
+      then `cd ~/Git/home-lab && just secrets` to write `SECRET_RESTIC_PASSWORD`.
+      ⚠️ This password is **not recoverable**. restic repositories are encrypted at rest, so a
+      backup whose password is lost is indistinguishable from no backup at all. It lives in
+      1Password specifically so it is not stored only on the machine being backed up.
+- [ ] Authorise dungeon's SSH key on the offsite Pi: `ssh-copy-id -i ~/.ssh/id_rsa.pub pi@100.98.200.16`
+      (run from dungeon; interactive, needs the Pi's password once).
+- [ ] Verify both destinations answer before trusting the schedule:
+      `ssh root@192.168.1.2 true && ssh fob true`
+- [ ] Dry-run it, which stages everything but writes no repository:
+      `cd ~/Git/home-lab && bash scripts/backup-tier1.sh --dry-run`
+- [ ] Then one real run by hand, and confirm the Pushover notification arrives. Success is
+      **not** silent here on purpose: the daily notification is the staleness detector, so if
+      it ever stops arriving, that is the alert.
+
+Restore procedure and failure triage: home-lab `docs/runbooks/backup-tier1.md`.
+
 ## Voice Input (Karabiner + Handy)
 Hold Caps Lock to dictate; a quick tap is Escape. Until these are done Karabiner is inert
 and Caps Lock still toggles caps. On headless dungeon, do them over VNC. Background and

--- a/nixos/hosts/macs/dungeon/default.nix
+++ b/nixos/hosts/macs/dungeon/default.nix
@@ -322,6 +322,43 @@ in {
     };
   };
 
+  # Tier-1 backup: the ~210 MB of ${SERVER_CONFIG_BASE} that genuinely cannot be
+  # regenerated — the Zigbee pairing database and coordinator NVRAM, zwave-js-ui's S2
+  # security keys, Home Assistant's .storage, the *arr databases, Plex's Preferences.xml.
+  # Losing any of it means re-pairing every Zigbee and Z-Wave device by hand. Everything
+  # else under that directory (~21 GB of Plex/Jellyfin/linuxgsm cache) is deliberately not
+  # backed up: losing it costs time, not information.
+  #
+  # Two independent restic repositories, not `restic copy` — unraid (on-LAN, parity) and
+  # fob (a Pi with an external disk, offsite). Independent so a corrupt repo or a password
+  # mistake cannot propagate, and offsite because Unraid is in the same building as
+  # dungeon. Rationale + restore procedure: home-lab/docs/runbooks/backup-tier1.md.
+  #
+  # 03:30, and RunAtLoad is deliberately FALSE — the two differences from every sibling
+  # agent here, both for the same reason. This one is not a watchdog; each run stages
+  # ~205 MB and pushes it over sftp to two hosts, and it notifies on *every* run including
+  # success. RunAtLoad would fire a full two-destination backup on every darwin-rebuild and
+  # every login, which is both wasteful and the fastest way to train you to ignore the
+  # notification that is the whole staleness-detection mechanism. Overlap is safe
+  # regardless: the script takes a single-flight lock and steals it only when stale.
+  launchd.user.agents.backup-tier1 = {
+    serviceConfig = {
+      ProgramArguments = [
+        "/bin/bash"
+        "/Users/${vars.user.name}/Git/home-lab/scripts/backup-tier1.sh"
+      ];
+      RunAtLoad = false;
+      StartCalendarInterval = [
+        {
+          Hour = 3;
+          Minute = 30;
+        }
+      ];
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/backup-tier1.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/backup-tier1.log";
+    };
+  };
+
   # Deploy oMLX with dungeon-specific settings (8GB hot cache for M3 Pro 36GB).
   # The symlink + jq-merge + restart logic lives in modules/darwin/omlx.nix.
   services.omlxDeploy = {

--- a/nixos/modules/darwin/homebrew-server.nix
+++ b/nixos/modules/darwin/homebrew-server.nix
@@ -18,6 +18,12 @@
       "node_exporter" # host CPU/disk/net/load/filesystem (:9100)
       "macmon" # Apple-Silicon temp/power/GPU/RAM via `macmon serve` (:9101)
       "glances" # native system-monitor web UI (:61208), replaces the container
+
+      # Tier-1 backup engine, driven by the backup-tier1 launchd agent in
+      # hosts/macs/dungeon. Deliberately on the whole server class rather than dungeon
+      # alone: restic is also the *restore* tool, and the one machine you cannot count on
+      # having during a restore is the one that was being backed up.
+      "restic"
     ];
 
     casks = [


### PR DESCRIPTION
The toolbox half of home-lab's tier-1 backup ([home-lab#46](https://github.com/GregHilston/home-lab/pull/46)).

That PR landed the script, 101 tests and a runbook, but nothing ran on a schedule: `restic` was not installed on dungeon and no launchd agent existed. Verified on dungeon before writing this — `command -v restic` came back empty and `launchctl list` showed the other four agents but no `backup-tier1`.

## What this adds

- **`restic`** in `modules/darwin/homebrew-server.nix`.
- **`launchd.user.agents.backup-tier1`** in `hosts/macs/dungeon/default.nix`, at 03:30 daily.
- A **post-deploy checklist** for the three things nix cannot do.

## Two deliberate departures from every sibling agent here

**`RunAtLoad = false`.** The others are watchdogs and should run the moment they load. This one stages ~205 MB and pushes it over sftp to two hosts, and it notifies on *every* run including success — that daily notification is the entire staleness-detection mechanism. `RunAtLoad` would fire a full two-destination backup on each `darwin-rebuild` and each login, which is both wasteful and the fastest possible way to train you to swipe the notification away without reading it.

**`StartCalendarInterval`, not `StartInterval`.** A backup wants a fixed quiet hour, not a period that drifts with whenever the agent last loaded. dungeon never sleeps (clamshell sleep is disabled in this same file), so 03:30 is reliably 03:30.

`restic` goes in `homebrew-server.nix` rather than dungeon alone because it is also the *restore* tool, and the one machine you cannot count on having during a restore is the one that was being backed up.

## Verification

```
$ nix eval .#darwinConfigurations.dungeon.config.launchd.user.agents.backup-tier1.serviceConfig --json
  Label=org.nixos.backup-tier1  RunAtLoad=false
  StartCalendarInterval=[{Hour=3, Minute=30}]
  ProgramArguments=[/bin/bash, …/Git/home-lab/scripts/backup-tier1.sh]

$ nix eval .#darwinConfigurations.dungeon.config.homebrew.brews --json | grep restic
  "name":"restic"

$ nix fmt -- --fail-on-change .
  formatted 3 files (0 changed)
```

## Not done here, and it must be done in this order

The agent pages on failure, so applying it before the password exists produces a `Backup FAILED` every night at 03:30:

1. Create `Infra/restic` in 1Password, then `just secrets` in home-lab.
2. `ssh-copy-id -i ~/.ssh/id_rsa.pub pi@100.98.200.16` from dungeon (interactive).
3. `sudo darwin-rebuild switch --flake ~/Git/toolbox/nixos#dungeon`.
4. One manual run, and confirm the Pushover notification arrives.

All four are now a checklist in `nixos/docs/darwin-post-deploy.md`.

## Also here

`chore(git): ignore the nix-generated .pre-commit-config.yaml symlink` — the `git-hooks` flake module writes that file whenever a nix command evaluates the flake, and it is a symlink into `/nix/store`. It was untracked and not ignored, so a `git add -A` sweeps it into a commit silently; this one nearly did.
