### PR TITLE
ci(flake): build a Darwin host for real, because evaluation cannot see a hash

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -49,7 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout the bot's branch
         uses: actions/checkout@v7
@@ -106,6 +105,12 @@ jobs:
     needs: update-lock
     if: needs.update-lock.outputs.pr-number != ''
     runs-on: macos-latest
+    # This job executes thousands of third-party build scripts — 2202 of the closure's
+    # derivations are fixed-output fetches — from a freshly bumped, unreviewed nixpkgs.
+    # The repo's default workflow permission is `write`, so without this it would be
+    # the one job here holding a push-capable token, and the one least entitled to it.
+    permissions:
+      contents: read
     outputs:
       failure-tail: ${{ steps.capture.outputs.tail }}
     steps:
@@ -124,13 +129,19 @@ jobs:
       - name: Cache Nix store
         uses: DeterminateSystems/magic-nix-cache-action@v8
 
+      # 6.6 GB of closure onto a runner documented at 14 GB is the least headroom in
+      # this design, so `No space left on device` is the likeliest false ❌. It already
+      # lands in the failure tail via the `error:` grep, which distinguishes it from a
+      # hash mismatch; `df` either side makes that unambiguous at a glance.
       - name: Build dungeon
         working-directory: nixos
         timeout-minutes: 90
         run: |
           set -o pipefail
+          df -h /
           nix build --no-link --print-build-logs \
             .#darwinConfigurations.dungeon.system 2>&1 | tee /tmp/build.log
+          df -h /
 
       # "Go read the logs" is a worse comment than the four lines that matter. A hash
       # mismatch says everything in `error:` + `specified:` + `got:`.
@@ -143,6 +154,9 @@ jobs:
           # died, hence `|| true` on every read.
           lines=$(grep -E 'error:|hash mismatch|specified:|got:' /tmp/build.log 2>/dev/null | head -20 || true)
           [ -n "$lines" ] || lines=$(tail -20 /tmp/build.log 2>/dev/null || true)
+          # Nothing useful to say beats an empty block: leave the key unset and let the
+          # report's `-n "$TAIL"` guard drop the section entirely.
+          [ -n "$lines" ] || exit 0
           {
             echo 'tail<<GH_EOF_MARKER'
             # A delimiter appearing in the payload would end the block early and let
@@ -195,12 +209,15 @@ jobs:
           "
 
           if [ "$BUILD" != "success" ] && [ -n "$TAIL" ]; then
+            # Four backticks, not three: nix build logs can contain a fenced block, and
+            # a three-backtick fence would be closed by it — spilling the rest of the
+            # log into prose and leaving a stray fence and a duplicate </details>.
             body="$body
           <details><summary>Build failure</summary>
 
-          \`\`\`
+          \`\`\`\`
           $TAIL
-          \`\`\`
+          \`\`\`\`
           </details>
           "
           fi

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -87,30 +87,122 @@ jobs:
         timeout-minutes: 30
         run: nix develop .#ci --command just validate
 
-      # Report unless the run was cancelled — `always()` would fire on cancellation
-      # too, and `job.status` is `cancelled` there, which would post a hard
-      # "do not merge" verdict about a lock nothing ever checked.
-      #
-      # A red run buried in the Actions tab is not a signal anyone sees; a comment on
-      # the PR is. GH_REPO because a failure in the checkout step above leaves an empty
-      # workspace, and `gh` would otherwise have no git remote to infer the repo from —
-      # failing silently in exactly the case this step exists to report.
-      - name: Report the result on the PR
-        if: ${{ !cancelled() }}
+  # Evaluation cannot see a fixed-output hash, because the hash is a literal in the
+  # expression and whether the fetched bytes match it is a build-time fact. On
+  # 2026-08-16 that gap was not theoretical: a bump passed `just validate` on all
+  # eight hosts and then died on a real build, because upstream had re-rolled the
+  # googlefonts/nanoemoji tarball and `jetbrains-mono` could no longer be built.
+  #
+  # So build one host for real. dungeon, because it is the deploy target and the
+  # headless one; and on macOS because that is where the gap actually bites —
+  # nixpkgs' aarch64-darwin outputs are cached far less reliably than x86_64-linux,
+  # so a Linux build would have substituted the cached result and noticed nothing.
+  #
+  # ~6.6 GB of closure, mostly substituted. Expensive for a per-PR check, entirely
+  # affordable once a week — and it is the only check here that answers the question
+  # `just dr` actually asks.
+  build-darwin:
+    name: Build a Darwin host for real
+    needs: update-lock
+    if: needs.update-lock.outputs.pr-number != ''
+    runs-on: macos-latest
+    outputs:
+      failure-tail: ${{ steps.capture.outputs.tail }}
+    steps:
+      - name: Checkout the bot's branch
+        uses: actions/checkout@v7
+        with:
+          ref: update_flake_lock_action
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Build dungeon
+        working-directory: nixos
+        timeout-minutes: 90
+        run: |
+          set -o pipefail
+          nix build --no-link --print-build-logs \
+            .#darwinConfigurations.dungeon.system 2>&1 | tee /tmp/build.log
+
+      # "Go read the logs" is a worse comment than the four lines that matter. A hash
+      # mismatch says everything in `error:` + `specified:` + `got:`.
+      - name: Capture the failure
+        id: capture
+        if: failure()
+        run: |
+          # `head` exits 0 on empty input, so the emptiness has to be tested rather
+          # than left to `||`. And the log may not exist at all if an earlier step
+          # died, hence `|| true` on every read.
+          lines=$(grep -E 'error:|hash mismatch|specified:|got:' /tmp/build.log 2>/dev/null | head -20 || true)
+          [ -n "$lines" ] || lines=$(tail -20 /tmp/build.log 2>/dev/null || true)
+          {
+            echo 'tail<<GH_EOF_MARKER'
+            # A delimiter appearing in the payload would end the block early and let
+            # the rest be parsed as workflow commands.
+            printf '%s\n' "$lines" | grep -v '^GH_EOF_MARKER$' || true
+            echo 'GH_EOF_MARKER'
+          } >> "$GITHUB_OUTPUT"
+
+  # Its own job so it can speak for both checks at once, and so a failure in either
+  # still gets said out loud. `!cancelled()` rather than `always()`: a cancelled run
+  # validated nothing, and "❌ do not merge" would be a verdict about work that never
+  # happened. `!cancelled()` also keeps this running when a *dependency* failed,
+  # which `success()` (the default) would not.
+  #
+  # A red run buried in the Actions tab is not a signal anyone sees; a comment on the
+  # PR is. GH_REPO because this job checks nothing out, so `gh` has no git remote to
+  # infer the repository from.
+  report:
+    name: Report on the PR
+    needs: [update-lock, validate, build-darwin]
+    if: ${{ !cancelled() && needs.update-lock.outputs.pr-number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment the verdict
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ needs.update-lock.outputs.pr-number }}
-          RESULT: ${{ job.status }}
+          EVAL: ${{ needs.validate.result }}
+          BUILD: ${{ needs.build-darwin.result }}
+          TAIL: ${{ needs.build-darwin.outputs.failure-tail }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ "$RESULT" = "success" ]; then
-            body="✅ **Lock validated** — \`nix flake check\` passed and every host evaluates to a toplevel derivation. ([run]($RUN_URL))
+          mark() { [ "$1" = "success" ] && echo "✅" || echo "❌"; }
 
-          Evaluation is not a build. It cannot catch a fixed-output hash mismatch in a
-          dependency, so real-build the host you are about to deploy (\`nix build
-          .#darwinConfigurations.<host>.system\`) before \`just dr\`/\`just fr\`."
+          if [ "$EVAL" = "success" ] && [ "$BUILD" = "success" ]; then
+            header="✅ **Lock validated** — safe to merge."
           else
-            body="❌ **Lock failed validation** — do not merge. ([run]($RUN_URL))"
+            header="❌ **Do not merge.**"
           fi
+
+          body="$header ([run]($RUN_URL))
+
+          | check | |
+          |---|---|
+          | \`nix flake check\` + all eight hosts evaluate | $(mark "$EVAL") \`$EVAL\` |
+          | \`darwinConfigurations.dungeon.system\` builds for real | $(mark "$BUILD") \`$BUILD\` |
+          "
+
+          if [ "$BUILD" != "success" ] && [ -n "$TAIL" ]; then
+            body="$body
+          <details><summary>Build failure</summary>
+
+          \`\`\`
+          $TAIL
+          \`\`\`
+          </details>
+          "
+          fi
+
           gh pr comment "$PR" --body "$body"

--- a/nixos/CLAUDE.md
+++ b/nixos/CLAUDE.md
@@ -185,9 +185,17 @@ nix build --no-link .#nixosConfigurations.<host>.config.system.build.toplevel
 ```
 
 Do it on the machine you are about to `just dr`/`just fr`, since a cached path on one
-host proves nothing about another architecture. This cannot be moved into CI — the
-runners have neither the time nor the disk for a full system closure — which is why it
-is written down here instead.
+host proves nothing about another architecture.
+
+For the **weekly bot bump** this is now automated: `update-flake-lock.yml`'s
+`build-darwin` job really builds `darwinConfigurations.dungeon.system` on a macOS
+runner and comments the verdict on the PR, so a green tick there does mean "it builds".
+It is macOS on purpose — nixpkgs' aarch64-darwin outputs are cached far less reliably
+than x86_64-linux, so a Linux runner substitutes the cached result and sees nothing.
+~6.6 GB of closure, mostly substituted: affordable weekly, not per-PR.
+
+That covers dungeon only. **For any lock change you make by hand, or before deploying
+to moria or citadel, still build it yourself** — nothing checks those.
 
 When a bump does turn out to be broken, check whether the fix has already landed
 upstream before working around it:


### PR DESCRIPTION
## Why

The weekly lock check says ✅ for locks it has never built. That is not a gap in the implementation — it is the ceiling of the technique. A fixed-output hash is a literal in the expression, and whether the fetched bytes match it is a build-time fact, so `nix flake check` plus eight `drvPath` evaluations cannot reach it.

This morning is the proof. A bump passed `just validate` on all eight hosts, then failed the moment anything built it:

```
error: hash mismatch in fixed-output derivation '...-source.drv':
         specified: sha256-gM53wlQSV/X7rDND6P7/fKpX0M28RDnWkGGOHQ+SK+g=
            got:    sha256-FysyKC01XBnRiur5RR9fcsTxQqE8x0JJHSoe3q6JtKc=
```

`just dr` would have failed on all three Macs. The mitigation shipped in #80 was a line in the ✅ comment telling a human to go build it themselves. That is a note asking someone to remember, which is not a check — and it was the thing standing between a bad lock and a broken deploy.

## What changed

**A `build-darwin` job really builds `darwinConfigurations.dungeon.system`.**

- **dungeon**, because it is the deploy target and the headless one.
- **macOS**, because that is where the gap actually bites. I checked: every NixOS host's derivation closure contains that same `jetbrains-mono`, so the platform *is* the whole difference — nixpkgs' aarch64-darwin outputs are cached far less reliably than x86_64-linux, and a Linux runner would have substituted a cached result and noticed nothing.
- **Affordable**: I measured the closure at **6.6 GB**, almost all substituted, bounded at 90 minutes. Far too expensive per-PR; fine once a week. This is the only check here that asks the question `just dr` asks.

**Reporting moves into its own job**, so one comment speaks for both checks and a failure in either is still said out loud:

| check | |
|---|---|
| `nix flake check` + all eight hosts evaluate | ✅ `success` |
| `darwinConfigurations.dungeon.system` builds for real | ❌ `failure` |

It keeps `!cancelled()` rather than `always()` — a cancelled run validated nothing, and "do not merge" would be a verdict about work that never happened. That predicate also keeps the job running when a *dependency* fails, which `success()` (the default for a job with `needs`) would not.

**On failure the comment carries the lines that matter**, not just a run link. For a hash mismatch, `error:` + `specified:` + `got:` is the entire diagnosis.

**`nixos/CLAUDE.md` is corrected.** The section I wrote this morning claimed a real build "cannot be moved into CI — the runners have neither the time nor the disk for a full system closure." Measuring rather than assuming showed otherwise. It now says what *is* still uncovered: dungeon only, so a hand-made lock change or a deploy to moria/citadel still needs you to build it yourself.

## Verification

- The report shell run against all three outcome combinations (both pass / eval passes + build fails / eval fails + build skipped) with a stubbed `gh` — output rendered correctly in each, including the collapsed failure block and its suppression when there is no tail.
- `bash -n` over every `run:` block; the whole workflow parsed and the job graph dumped.
- The **existing** job was proven live first: I dispatched `update-flake-lock.yml` manually, it opened #83, and the `validate` job ran and commented on it. So the structure this PR extends is known-good, not assumed-good.
- The `Capture the failure` step is written so `head`'s exit-0-on-empty-input cannot be mistaken for "found something", the log being absent cannot fail the step, and a delimiter appearing in the payload cannot end the heredoc early.

## Risk

Low, and confined to a weekly scheduled workflow — no host configuration, no per-PR CI, nothing on a deploy path.

The realistic failure mode is a macOS runner that is slow or short on disk, which fails the `build-darwin` job and posts ❌ on a lock that may be fine. That is the safe direction to be wrong in, it is bounded at 90 minutes, and the report distinguishes which check failed. If it proves flaky, dropping the job back to informational is a one-line `continue-on-error`.
