### PR TITLE
fix(darwin): keep docker-desktop off the hosts that run OrbStack

### DIFF
--- a/nixos/CLAUDE.md
+++ b/nixos/CLAUDE.md
@@ -433,6 +433,37 @@ re-run `just dr <host>`. (Durable option if it recurs: set `HOMEBREW_NO_INSTALL_
 so installs stop auto-cleaning — note this is unrelated to `homebrew.onActivation.cleanup`
 in `modules/darwin/homebrew-base.nix`, which only controls Brewfile-drift uninstalls.)
 
+## ⚠️ Never put `docker-desktop` in `homebrew-base.nix`
+
+`docker-desktop` is declared in `hosts/macs/citadel/default.nix` **only**. dungeon and moria get
+`orbstack` from `modules/darwin/homebrew-server.nix`, and the two casks both claim
+`/usr/local/bin/docker`.
+
+`onActivation.upgrade = true` turns that collision into a recurring, silent one: every
+`darwin-rebuild switch` runs `brew upgrade`, and whichever cask brew touches last re-installs its
+own symlinks over the other's. **`cleanup = "none"` means dropping a cask from the Nix lists never
+uninstalls it** — the config and the machine drift apart quietly.
+
+This actually happened. `docker-desktop` sat in the shared Darwin cask list from `b72fe6b`
+(2026-03-22, the commit that created dungeon's config) — as `"docker"`, which is easy to read as
+"the docker CLI"; `10d75fd` renamed it to `docker-desktop` on 2026-04-18 tracking the upstream
+cask rename, and `321ed35` carried it into `homebrew-base.nix`. `orbstack` arrived five days after
+dungeon's config was born (`ea2e06b`, 2026-03-27) and nobody removed the other one. On
+**2026-08-17 08:28** a cask bump to Docker Desktop 4.87.0 repointed `/usr/local/bin/docker` at
+`Docker.app`, which silently disabled a home-lab launchd watchdog that resolved `docker` through
+it (see home-lab `docs/runbooks/proton-port-sync-failed.md`).
+
+Docker Desktop was never even *running* on dungeon — `/var/run/docker.sock` has pointed at
+OrbStack throughout, and the active docker context is `orbstack`. Only the CLI symlink was taken,
+which is why nothing looked broken.
+
+**Check any Mac in one line** — a host should never print both:
+
+```bash
+brew list --cask --versions | grep -iE "docker-desktop|orbstack"
+readlink /usr/local/bin/docker      # want …/OrbStack.app/… on dungeon and moria
+```
+
 ## `just dr` re-prompts for a password at every cask — don't chase the sudo ticket
 
 Homebrew runs `sudo --reset-timestamp` **unconditionally at the top of every invocation**

--- a/nixos/hosts/macs/citadel/default.nix
+++ b/nixos/hosts/macs/citadel/default.nix
@@ -67,6 +67,16 @@
       # Dev
       "google-cloud-sdk"
 
+      # Docker Desktop is citadel-only ON PURPOSE. It used to live in
+      # homebrew-base.nix (every Mac), which put it on dungeon and moria alongside
+      # OrbStack — see modules/darwin/homebrew-server.nix. Two Docker runtimes on one
+      # host fight over /usr/local/bin/docker, and `onActivation.upgrade = true` means
+      # every darwin-rebuild re-installs the loser's symlinks. That is exactly what
+      # happened on dungeon on 2026-08-17: a Docker Desktop cask bump repointed
+      # /usr/local/bin/docker at Docker.app and silently disabled a launchd watchdog
+      # that resolved `docker` through it. citadel has no OrbStack, so it is safe here.
+      "docker-desktop"
+
       # Networking
       "mozilla-vpn"
     ];

--- a/nixos/modules/darwin/homebrew-base.nix
+++ b/nixos/modules/darwin/homebrew-base.nix
@@ -72,7 +72,6 @@
 
       # Dev
       "bruno"
-      "docker-desktop"
       "dbeaver-community"
       "db-browser-for-sqlite"
       "ngrok"

--- a/nixos/modules/darwin/homebrew-server.nix
+++ b/nixos/modules/darwin/homebrew-server.nix
@@ -30,6 +30,12 @@
       "google-chrome"
       "discord"
       "calibre"
+
+      # OrbStack is THE container runtime on this host class — home-lab's
+      # docker-compose stack, its NFS volumes and its USB passthrough all assume it.
+      # ⚠️ Never add "docker-desktop" to homebrew-base.nix: both casks claim
+      # /usr/local/bin/docker, and with onActivation.upgrade = true whichever one brew
+      # touches last wins on every rebuild. It lives in hosts/macs/citadel only.
       "orbstack"
       "shortcat"
       "tailscale-app"


### PR DESCRIPTION
## Summary

dungeon and moria were being handed **both** container runtimes: `docker-desktop` from the shared `homebrew-base.nix`, and `orbstack` from `homebrew-server.nix`. Both casks claim `/usr/local/bin/docker`.

This moves `docker-desktop` to `hosts/macs/citadel/default.nix`, the only host that actually wants it — it's dock-pinned there and has no OrbStack.

## Why it matters

`onActivation.upgrade = true` means **every** `darwin-rebuild switch` runs `brew upgrade`, and whichever cask brew touches last re-installs its own symlinks over the other's. It's a recurring collision, not a one-off.

It fired on dungeon on **2026-08-17 08:28**: a cask bump to Docker Desktop 4.87.0 repointed `/usr/local/bin/docker` at `Docker.app`. That silently disabled a home-lab launchd watchdog which resolved `docker` through that path — it stood down on `docker unresponsive` for six days while Docker was perfectly healthy. Full write-up in home-lab `docs/runbooks/proton-port-sync-failed.md` (PR: `fix/silent-watchdog-and-1337x-ban`).

**Docker Desktop was never even running on dungeon.** `/var/run/docker.sock` has pointed at OrbStack throughout and the active context was `orbstack`, so only the CLI symlink was taken — which is exactly why nothing looked broken and it took a watchdog audit to find.

## How it got there

| Commit | Date | What |
|---|---|---|
| `b72fe6b` | 2026-03-22 | Created dungeon's nix-darwin config, including `"docker"` in the shared cask list — the cask's name at the time, and easy to read as "the docker CLI" |
| `ea2e06b` | 2026-03-27 | Added `orbstack`, five days later. Nobody removed the other one |
| `10d75fd` | 2026-04-18 | Renamed `docker` → `docker-desktop`, tracking the upstream cask rename. No behaviour change, but the name finally became honest |
| `321ed35` | 2026-06-29 | The flake-parts dedup carried it into `homebrew-base.nix` — *every* Mac |

## Verification

Evaluated cask sets per host confirm the split:

```
dungeon   docker-desktop=no   orbstack=YES
moria     docker-desktop=no   orbstack=YES
citadel   docker-desktop=YES  orbstack=no
```

And the generated Brewfile for dungeon now contains `cask "orbstack"` only, against both casks in the currently-active generation.

`nix fmt --ci` clean.

## ⚠️ This does not uninstall anything

`onActivation.cleanup = "none"`, so dropping a cask from the Nix lists never removes it from the machine — config and host drift apart quietly.

- **dungeon** was cleaned up by hand: cask uninstalled, `/usr/local/bin/docker` and `docker-credential-osxkeychain` repointed at OrbStack, Docker Desktop's dangling `cli-plugins` symlinks cleared, `desktop-linux` context removed. Verified afterwards: 57 containers up, `docker compose` v5.1.2, and `dev.orbstack.OrbStack.privhelper` intact (USB passthrough for the Zigbee/Z-Wave dongles depends on it).
- **moria still needs the same pass.** Check with `brew list --cask --versions | grep -i docker; readlink /usr/local/bin/docker`.

## Sequencing note

Until this is merged and rebuilt, a `darwin-rebuild switch` from `master` reads the old Brewfile and **reinstalls Docker Desktop**, re-taking `/usr/local/bin/docker`.
