### PR TITLE
fix(bin): pi-workers' empty-state message named the wrong discovery rule

### DIFF
--- a/bin/pi-workers.py
+++ b/bin/pi-workers.py
@@ -271,7 +271,12 @@ def gather(paths: list[Path], stall_seconds: float) -> list[dict[str, Any]]:
 
 def render_table(workers: list[dict[str, Any]], width: int) -> str:
     if not workers:
-        return "No pi workers found. Looked for directories containing a .pi/ directory."
+        # Name the actual rule: someone debugging a missing worker will have
+        # created `.pi/` and be wondering why it does not show up.
+        return (
+            "No pi workers found. A worker is a directory whose .pi/ holds "
+            "status.json or guardrails.json."
+        )
     header = f"{'worker':<20} {'state':<9} {'turn':>4} {'tools':>5} {'age':>7} {'cost':>9}  doing"
     rows = [header, "-" * min(len(header) + 20, width)]
     for worker in workers:

--- a/tests/test_pi_workers.py
+++ b/tests/test_pi_workers.py
@@ -290,7 +290,12 @@ class Rendering(unittest.TestCase):
         self.assertNotIn("Needs attention: issue-30", table)
 
     def test_the_table_says_something_useful_when_there_are_no_workers(self):
-        self.assertIn("No pi workers found", workers.render_table([], 200))
+        empty = workers.render_table([], 200)
+        self.assertIn("No pi workers found", empty)
+        # It must name the real rule. Saying "a directory containing .pi/" sent
+        # anyone debugging a missing worker looking in the wrong place.
+        for marker in workers.WORKER_MARKERS:
+            self.assertIn(marker, empty)
 
     def test_table_rows_are_truncated_to_the_given_width(self):
         write_worker(self.root, "issue-30", working_status(lastToolBrief="x" * 400))


### PR DESCRIPTION
Follow-up to #88, found smoke-testing the merged code against a real repo.

`render_table`'s empty-state message still said workers are "directories containing a .pi/ directory". That was true before review narrowed discovery to exclude $HOME — `~/.pi` is pi's own config directory, so the loose rule reported $HOME as a phantom dead worker.

The message is the one place someone lands when a worker *isn't* showing up, so it was actively misleading: follow it and you'd create `.pi/` and still see nothing. It now names the real markers (`status.json` or `guardrails.json`), and the test asserts it names them rather than just asserting it says something.

35 pi-workers tests green.