### PR TITLE
Add Vorssaint to moria and citadel, with a seeded feature set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,9 @@ worth knowing from here:
 - **There is no config file.** The Features hub is GUI-only and its settings export goes
   through a save panel. What it does have is a plain UserDefaults domain
   (`com.vorssaint.utils`), one bool per feature, so the module seeds the whole set with
-  `defaults write` from its launchd agent before the app's first launch. That is a
+  `defaults write` during activation, after Homebrew has installed the cask and before
+  anyone has opened the app. (Not from the launchd agent: agents activate *before*
+  Homebrew, so that version raced the cask and then raced the human — and lost.) It is a
   **one-time** seed gated on the app's own `hasOnboarded` marker, not a rebuild-time
   rewrite — editing the feature list does nothing to a Mac already set up until you
   `defaults delete com.vorssaint.utils hasOnboarded` and kickstart the agent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,33 @@ Launching, permissions, and why the app's own "launch at login" stays off are al
 `modules/darwin/homebrew-base.nix`, launched by `modules/darwin/ice.nix` — same
 launchd pattern as Handy, documented in `nixos/CLAUDE.md`.
 
+## Mac Utilities — Vorssaint
+
+[Vorssaint](https://github.com/vorssaint/vorssaint-utils) is a PowerToys-shaped menu bar
+suite: per-app volume and output, keep-awake with the lid closed, a better screenshot and
+text-from-screen, ⌘X/⌘V in Finder, quit-on-close, system stats, a file shelf. **moria and
+citadel only** — dungeon is headless.
+
+`nixos/modules/darwin/vorssaint.nix` owns it and explains itself at length. The two things
+worth knowing from here:
+
+- **There is no config file.** The Features hub is GUI-only and its settings export goes
+  through a save panel. What it does have is a plain UserDefaults domain
+  (`com.vorssaint.utils`), one bool per feature, so the module seeds the whole set with
+  `defaults write` from its launchd agent before the app's first launch. That is a
+  **one-time** seed gated on the app's own `hasOnboarded` marker, not a rebuild-time
+  rewrite — editing the feature list does nothing to a Mac already set up until you
+  `defaults delete com.vorssaint.utils hasOnboarded` and kickstart the agent.
+- **It overlaps four things already deployed here**, and the module's default list is
+  picked to dodge them: no `superKey` (Karabiner owns Caps Lock), no window features
+  (AeroSpace), no command bar or clipboard history (Raycast), and no `scrollInverter`
+  (it would double-invert against `com.apple.swipescrolldirection = false` in
+  `modules/darwin/common.nix`). The `monitor*` features *do* overlap the `stats` cask,
+  deliberately and reversibly.
+
+Permissions are still manual — TCC is outside nix's reach. See
+`nixos/docs/darwin-post-deploy.md`.
+
 ## Dotfiles
 
 **Pattern:** dotfiles are portable, plain-syntax, and stow-deployed (the source of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,12 +125,14 @@ worth knowing from here:
   **one-time** seed gated on the app's own `hasOnboarded` marker, not a rebuild-time
   rewrite — editing the feature list does nothing to a Mac already set up until you
   `defaults delete com.vorssaint.utils hasOnboarded` and kickstart the agent.
-- **It overlaps four things already deployed here**, and the module's default list is
-  picked to dodge them: no `superKey` (Karabiner owns Caps Lock), no window features
-  (AeroSpace), no command bar or clipboard history (Raycast), and no `scrollInverter`
-  (it would double-invert against `com.apple.swipescrolldirection = false` in
-  `modules/darwin/common.nix`). The `monitor*` features *do* overlap the `stats` cask,
-  deliberately and reversibly.
+- **It overlaps four things already deployed here**, and the list only dodges some of
+  them on purpose. Out for good: `superKey` (Karabiner owns Caps Lock — two event taps
+  on one key is broken, not just redundant) and `scrollInverter` (it would double-invert
+  against `com.apple.swipescrolldirection = false` in `modules/darwin/common.nix`).
+  Deliberately in, despite overlapping: the app switcher and Dock previews (AeroSpace),
+  the command bar and clipboard history (Raycast), and the `monitor*` readouts (the
+  `stats` cask). The command bar is installed with its shortcut left **off**, because its
+  default is ⌥Space — Raycast's hotkey.
 
 Permissions are still manual — TCC is outside nix's reach. See
 `nixos/docs/darwin-post-deploy.md`.

--- a/nixos/CLAUDE.md
+++ b/nixos/CLAUDE.md
@@ -125,6 +125,15 @@ The shape is always the same, and *why* is the part worth remembering:
 - **`RunAtLoad` only, never `KeepAlive`.** `open` exits as soon as LaunchServices takes
   over, so KeepAlive reads that as a crash and respawns forever. The tradeoff: a real
   crash isn't restarted. Fine — the missing menu-bar icon is the tell.
+  > `vorssaint.nix` is the one exception, and it is the narrow form:
+  > `KeepAlive = { SuccessfulExit = false; }` retries only while the script *fails*, and
+  > its script fails only while the cask is missing, so the job stops restarting itself
+  > the moment Homebrew has installed the app. It needs that because there is no other
+  > recovery: nix-darwin reloads a user agent only when its generated plist differs from
+  > the installed one, so on an unchanged config the agent is never re-bootstrapped and
+  > `RunAtLoad` never fires again — a `just dr` does **not** re-run these scripts. That
+  > only matters for an agent that does work beyond `open`, which is why ice and handy
+  > can stay on the plain rule.
 - **Not the app's own "Launch at login" toggle.** Those register an `SMAppService` login
   item in app-written state (e.g. Handy's `settings_store.json`) that nix neither owns nor
   can assert. Keep the in-app toggle **off** so the two don't double-register.

--- a/nixos/CLAUDE.md
+++ b/nixos/CLAUDE.md
@@ -99,11 +99,20 @@ for an ARM host.
 
 Menu-bar apps have to already be running to do anything, and they fail *silently* when
 they aren't — no Handy means Caps Lock still behaves and nothing dictates; no Ice means
-the stock cluttered menu bar. So each gets a launchd user agent: `modules/darwin/handy.nix`
-(imported per-host by citadel and moria; headless dungeon has the cask but no use for a
-dictation app) and `modules/darwin/ice.nix` (imported from `modules/darwin/common.nix`, so
-all three Macs). The Linux equivalent is a home-manager `systemd.user.services.*` unit
-bound to `graphical-session.target` — see handy in `modules/home/default.nix`.
+the stock cluttered menu bar. So each gets a launchd user agent:
+
+- `modules/darwin/ice.nix` — imported from `modules/darwin/common.nix`, so all three Macs.
+- `modules/darwin/handy.nix` — per-host (citadel, moria); headless dungeon has the cask but
+  no use for a dictation app.
+- `modules/darwin/vorssaint.nix` — per-host (citadel, moria), for the same reason. The one
+  that does more than launch: its script also seeds Vorssaint's Features hub the first time,
+  because the app has no config file, only a UserDefaults domain. That is *why* the seed
+  lives in the agent — a launchd user agent runs as the user, and `defaults write` from
+  root-at-activation would have configured root's copy. Its own header has the full
+  reasoning, including why the keys are seeded once rather than enforced every rebuild.
+
+The Linux equivalent is a home-manager `systemd.user.services.*` unit bound to
+`graphical-session.target` — see handy in `modules/home/default.nix`.
 
 The shape is always the same, and *why* is the part worth remembering:
 

--- a/nixos/CLAUDE.md
+++ b/nixos/CLAUDE.md
@@ -104,12 +104,13 @@ the stock cluttered menu bar. So each gets a launchd user agent:
 - `modules/darwin/ice.nix` — imported from `modules/darwin/common.nix`, so all three Macs.
 - `modules/darwin/handy.nix` — per-host (citadel, moria); headless dungeon has the cask but
   no use for a dictation app.
-- `modules/darwin/vorssaint.nix` — per-host (citadel, moria), for the same reason. The one
-  that does more than launch: its script also seeds Vorssaint's Features hub the first time,
-  because the app has no config file, only a UserDefaults domain. That is *why* the seed
-  lives in the agent — a launchd user agent runs as the user, and `defaults write` from
-  root-at-activation would have configured root's copy. Its own header has the full
-  reasoning, including why the keys are seeded once rather than enforced every rebuild.
+- `modules/darwin/vorssaint.nix` — per-host (citadel, moria), for the same reason. Plain
+  `open -a` like the other two; its *other* job, seeding Vorssaint's Features hub (the app
+  has no config file, only a UserDefaults domain), deliberately does **not** live in the
+  agent. Activation order is agents → Homebrew → postActivation, so an agent-hosted seed
+  runs before the cask exists and then has to race whoever opens the app first — a race it
+  lost on moria's first deploy, permanently, because the app's wizard sets the same
+  "already set up" marker the seed is gated on. Its header has the full reasoning.
 
 The Linux equivalent is a home-manager `systemd.user.services.*` unit bound to
 `graphical-session.target` — see handy in `modules/home/default.nix`.
@@ -125,15 +126,12 @@ The shape is always the same, and *why* is the part worth remembering:
 - **`RunAtLoad` only, never `KeepAlive`.** `open` exits as soon as LaunchServices takes
   over, so KeepAlive reads that as a crash and respawns forever. The tradeoff: a real
   crash isn't restarted. Fine — the missing menu-bar icon is the tell.
-  > `vorssaint.nix` is the one exception, and it is the narrow form:
-  > `KeepAlive = { SuccessfulExit = false; }` retries only while the script *fails*, and
-  > its script fails only while the cask is missing, so the job stops restarting itself
-  > the moment Homebrew has installed the app. It needs that because there is no other
-  > recovery: nix-darwin reloads a user agent only when its generated plist differs from
-  > the installed one, so on an unchanged config the agent is never re-bootstrapped and
-  > `RunAtLoad` never fires again — a `just dr` does **not** re-run these scripts. That
-  > only matters for an agent that does work beyond `open`, which is why ice and handy
-  > can stay on the plain rule.
+  > Worth knowing when you are tempted to put real work in one of these: nix-darwin
+  > reloads a user agent only when its generated plist *differs* from the installed
+  > one, so on an unchanged config the agent is never re-bootstrapped and `RunAtLoad`
+  > never fires again. A `just dr` does **not** re-run these scripts. That is fine for
+  > `open -a`, which the next login handles, and it is one of the reasons `vorssaint.nix`
+  > does its preference seeding from `postActivation` instead.
 - **Not the app's own "Launch at login" toggle.** Those register an `SMAppService` login
   item in app-written state (e.g. Handy's `settings_store.json`) that nix neither owns nor
   can assert. Keep the in-app toggle **off** so the two don't double-register.

--- a/nixos/docs/darwin-post-deploy.md
+++ b/nixos/docs/darwin-post-deploy.md
@@ -137,13 +137,16 @@ See `modules/darwin/pi-web.nix`.
       Features hub, so there is nothing to pick on first launch — only permissions to grant.
       Leave its Settings → "Launch at login" **off**; the launchd agent owns that.
       Grant these, in rough order of how much stops working without them:
-      - **Accessibility** — the volume mixer, keep awake, ⌘X/⌘V in Finder, quit-on-close,
-        smooth scrolling and Cleaning Mode. This is the one that matters.
+      - **Accessibility** — ⌘X/⌘V in Finder, quit-on-close, smooth scrolling, the file
+        shelf and Cleaning Mode.
       - **Screen Recording** — the screenshot tool and copy-text-from-screen.
       - **System Audio Recording** — per-app volume and per-app output. Without it every
         app just rides the normal system output.
       - **Automation → Finder** — emptying the Trash from Quick Toggles, ⌘X/⌘V, and the
         uninstaller. Prompts on first use rather than up front.
+      - **Automation → Terminal** and **App Management** — the Homebrew pane. Without
+        them it lists packages but installs and removes nothing. Both prompt the first
+        time you use it rather than up front.
       - **Full Disk Access**, optional — lets the Cleaner and Uninstaller see more than the
         reachable places. Skippable; both work without it.
       > Nothing is broken while a grant is missing — a feature that needs one sits inert
@@ -151,10 +154,11 @@ See `modules/darwin/pi-web.nix`.
       > use each grant. Nothing here can be declared: TCC is outside nix's reach.
 - [ ] Confirm the seed actually ran: `grep vorssaint ~/Library/Logs/vorssaint.log` should
       say `seeding the Features hub with mixer, keepAwake, …` on the first activation and
-      `already set up` on every one after. On a brand-new host the first line can instead be
-      `Unable to find application named 'Vorssaint'` — the agent bootstrapped before
-      Homebrew installed the cask. Harmless: the seed still landed, and the next `just dr`
-      (or the next login) launches it.
+      `already set up` on every one after. On a brand-new host the first line is instead
+      `/Applications/Vorssaint.app is not installed yet, retrying later` — nix-darwin
+      activates user agents before it runs Homebrew, so the first pass finds no app. It
+      deliberately seeds nothing in that case and retries every 5 minutes, so the line to
+      wait for is the `seeding` one a few minutes after `just dr` finishes.
       > To re-seed deliberately after editing the feature list — it is otherwise a
       > once-per-Mac write, so an edit alone changes nothing on a host already set up:
       > ```

--- a/nixos/docs/darwin-post-deploy.md
+++ b/nixos/docs/darwin-post-deploy.md
@@ -137,18 +137,16 @@ See `modules/darwin/pi-web.nix`.
       Features hub, so there is nothing to pick on first launch — only permissions to grant.
       Leave its Settings → "Launch at login" **off**; the launchd agent owns that.
       Grant these, in rough order of how much stops working without them:
-      - **Accessibility** — ⌘X/⌘V in Finder, quit-on-close, smooth scrolling, the file
-        shelf and Cleaning Mode.
-      - **Screen Recording** — the screenshot tool and copy-text-from-screen.
+      - **Accessibility** — the app switcher, Dock previews, quit-on-close, ⌘X/⌘V in
+        Finder, paste-as-plain-text, the volume mixer and external-display brightness.
+        This is the one that matters.
+      - **Screen Recording** — the switcher's and Dock preview's window thumbnails, plus
+        the screenshot, screen-recording and copy-text-from-screen tools.
       - **System Audio Recording** — per-app volume and per-app output. Without it every
         app just rides the normal system output.
-      - **Automation → Finder** — emptying the Trash from Quick Toggles, ⌘X/⌘V, and the
-        uninstaller. Prompts on first use rather than up front.
-      - **Automation → Terminal** and **App Management** — the Homebrew pane. Without
-        them it lists packages but installs and removes nothing. Both prompt the first
-        time you use it rather than up front.
-      - **Full Disk Access**, optional — lets the Cleaner and Uninstaller see more than the
-        reachable places. Skippable; both work without it.
+      - **Automation → Finder** — ⌘X/⌘V in Finder.
+      - **Camera** — the camera preview mirror. **Microphone** — the optional voice track
+        in screen recordings. Both prompt the first time you use them.
       > Nothing is broken while a grant is missing — a feature that needs one sits inert
       > and says so on Vorssaint's own Permissions page, which also lists which features
       > use each grant. Nothing here can be declared: TCC is outside nix's reach.

--- a/nixos/docs/darwin-post-deploy.md
+++ b/nixos/docs/darwin-post-deploy.md
@@ -152,13 +152,11 @@ See `modules/darwin/pi-web.nix`.
       > Nothing is broken while a grant is missing — a feature that needs one sits inert
       > and says so on Vorssaint's own Permissions page, which also lists which features
       > use each grant. Nothing here can be declared: TCC is outside nix's reach.
-- [ ] Confirm the seed actually ran: `grep vorssaint ~/Library/Logs/vorssaint.log` should
-      say `seeding the Features hub with mixer, keepAwake, …` on the first activation and
-      `already set up` on every one after. On a brand-new host the first line is instead
-      `/Applications/Vorssaint.app is not installed yet, retrying later` — nix-darwin
-      activates user agents before it runs Homebrew, so the first pass finds no app. It
-      deliberately seeds nothing in that case and retries every 5 minutes, so the line to
-      wait for is the `seeding` one a few minutes after `just dr` finishes.
+- [ ] Confirm the seed ran. It happens during `just dr` itself, after Homebrew, so the
+      output is in the rebuild's own log: `seeding the Features hub with mixer, keepAwake,
+      …` the first time and `already set up, leaving the Features hub alone` on every
+      rebuild after. A `WARNING: the Vorssaint seed did not finish` line means it fell
+      back to the app's own wizard — the rebuild is not failed by it.
       > To re-seed deliberately after editing the feature list — it is otherwise a
       > once-per-Mac write, so an edit alone changes nothing on a host already set up:
       > ```

--- a/nixos/docs/darwin-post-deploy.md
+++ b/nixos/docs/darwin-post-deploy.md
@@ -132,3 +132,32 @@ See `modules/darwin/pi-web.nix`.
       **off** — the launchd agent owns that, and both would double-register.
 - [ ] Arrange the menu bar in Ice: drag icons above/below the divider with ⌘-drag to choose
       what stays visible vs. hidden
+- [ ] **Vorssaint** (moria, citadel) - the menu-bar utility suite. Like Ice, it is launched
+      at login by `modules/darwin/vorssaint.nix`, and unlike Ice it also seeds its own
+      Features hub, so there is nothing to pick on first launch — only permissions to grant.
+      Leave its Settings → "Launch at login" **off**; the launchd agent owns that.
+      Grant these, in rough order of how much stops working without them:
+      - **Accessibility** — the volume mixer, keep awake, ⌘X/⌘V in Finder, quit-on-close,
+        smooth scrolling and Cleaning Mode. This is the one that matters.
+      - **Screen Recording** — the screenshot tool and copy-text-from-screen.
+      - **System Audio Recording** — per-app volume and per-app output. Without it every
+        app just rides the normal system output.
+      - **Automation → Finder** — emptying the Trash from Quick Toggles, ⌘X/⌘V, and the
+        uninstaller. Prompts on first use rather than up front.
+      - **Full Disk Access**, optional — lets the Cleaner and Uninstaller see more than the
+        reachable places. Skippable; both work without it.
+      > Nothing is broken while a grant is missing — a feature that needs one sits inert
+      > and says so on Vorssaint's own Permissions page, which also lists which features
+      > use each grant. Nothing here can be declared: TCC is outside nix's reach.
+- [ ] Confirm the seed actually ran: `grep vorssaint ~/Library/Logs/vorssaint.log` should
+      say `seeding the Features hub with mixer, keepAwake, …` on the first activation and
+      `already set up` on every one after. On a brand-new host the first line can instead be
+      `Unable to find application named 'Vorssaint'` — the agent bootstrapped before
+      Homebrew installed the cask. Harmless: the seed still landed, and the next `just dr`
+      (or the next login) launches it.
+      > To re-seed deliberately after editing the feature list — it is otherwise a
+      > once-per-Mac write, so an edit alone changes nothing on a host already set up:
+      > ```
+      > defaults delete com.vorssaint.utils hasOnboarded
+      > launchctl kickstart -k "gui/$(id -u)/org.nixos.vorssaint"
+      > ```

--- a/nixos/hosts/macs/citadel/default.nix
+++ b/nixos/hosts/macs/citadel/default.nix
@@ -13,6 +13,11 @@
     # Launch Handy at login so the Caps-Lock-hold → F18 dictation hotkey works
     # without opening the app by hand.
     ../../../modules/darwin/handy.nix
+    # Vorssaint — the menu-bar utility suite. Per-host (citadel, moria) rather
+    # than from common.nix: headless dungeon has no one sitting at a menu bar,
+    # and almost every feature is an interactive one. The feature set it comes
+    # up with is the module's `features` default.
+    ../../../modules/darwin/vorssaint.nix
   ];
 
   networking.hostName = "citadel";
@@ -90,6 +95,12 @@
     enable = true;
     cacheSize = "12GB";
   };
+
+  # Vorssaint — menu-bar utility suite (imported above). Seeds its Features hub
+  # once on a Mac that has never run it; after that the hub owns the choice.
+  # The feature list, and what it deliberately leaves out to stay clear of
+  # Karabiner, AeroSpace and Raycast, is in modules/darwin/vorssaint.nix.
+  services.vorssaint.enable = true;
 
   home-manager.users.${vars.user.name} = {
     # 6-bit is the best quality/memory balance for 48GB

--- a/nixos/hosts/macs/moria/default.nix
+++ b/nixos/hosts/macs/moria/default.nix
@@ -12,6 +12,11 @@
     # Launch Handy at login so the Caps-Lock-hold → F18 dictation hotkey works
     # without opening the app by hand.
     ../../../modules/darwin/handy.nix
+    # Vorssaint — the menu-bar utility suite. Per-host (citadel, moria) rather
+    # than from common.nix: headless dungeon has no one sitting at a menu bar,
+    # and almost every feature is an interactive one. The feature set it comes
+    # up with is the module's `features` default.
+    ../../../modules/darwin/vorssaint.nix
     # PI WEB — supervise pi sessions from a browser. moria only: it is the
     # 128GB box and already runs oMLX, so sessions and inference stay together.
     ../../../modules/darwin/pi-web.nix
@@ -53,6 +58,12 @@
     enable = true;
     cacheSize = "32GB";
   };
+
+  # Vorssaint — menu-bar utility suite (imported above). Seeds its Features hub
+  # once on a Mac that has never run it; after that the hub owns the choice.
+  # The feature list, and what it deliberately leaves out to stay clear of
+  # Karabiner, AeroSpace and Raycast, is in modules/darwin/vorssaint.nix.
+  services.vorssaint.enable = true;
 
   # Keep pi's Reddit session cookie current by copying it out of Firefox.
   #

--- a/nixos/modules/darwin/vorssaint.nix
+++ b/nixos/modules/darwin/vorssaint.nix
@@ -1,8 +1,16 @@
 # Vorssaint — one menu bar app in place of a dozen small Mac utilities.
 #
 # https://github.com/vorssaint/vorssaint-utils (GPL-3.0-or-later, Swift, bundle
-# id com.vorssaint.utils). Installed from the `vorssaint` cask: arm64 + macOS 14
-# only, which every Mac here satisfies, and Developer-ID signed + notarized.
+# id com.vorssaint.utils). Installed from the `vorssaint` cask, which is
+# Developer-ID signed, notarized, and `depends_on arch: :arm64` — the macOS 14
+# floor is the app's own (LSMinimumSystemVersion). Every Mac here clears both.
+#
+# The cask is also `auto_updates true`, which means `brew upgrade` SKIPS it
+# without `--greedy`: despite `onActivation.upgrade = true` in
+# ./homebrew-base.nix, the app's own updater is what actually keeps it current,
+# and the installed version drifts from the cask's. That is left alone on
+# purpose — pinning it by turning the in-app updater off would freeze the app
+# at whatever version first landed, since nothing else would move it.
 #
 # This module does three things, and each is enabled per host by importing it
 # and setting `services.vorssaint.enable`:
@@ -40,23 +48,36 @@
 #   defaults delete com.vorssaint.utils hasOnboarded
 #   launchctl kickstart -k "gui/$(id -u)/org.nixos.vorssaint"
 #
-# Note that `brew uninstall --cask vorssaint` deletes the whole preferences
-# plist, which clears `hasOnboarded` too — so a reinstall re-seeds on its own.
+# A plain `brew uninstall --cask vorssaint` does NOT reset this: its cask only
+# quits the app and removes the bundle, and the preferences plist is listed
+# under `zap`. So reinstalling after a plain uninstall keeps `hasOnboarded` and
+# does not re-seed; `brew uninstall --zap --cask vorssaint` is the one that
+# takes the plist with it.
 #
 # ## Why the seed lives in the launchd agent rather than postActivation
 #
 # `system.activationScripts.postActivation` runs as root, and `defaults write`
-# resolves its domain from the effective user: seeding there would configure
-# root's Vorssaint, not the one with a menu bar. A launchd *user* agent already
-# runs as the user, in their GUI session, so cfprefsd sees the writes. Folding
-# the seed and the launch into one script also fixes the ordering for free —
-# the app can never start before its features are chosen, which matters because
-# a first launch with nothing written runs the app's own Essentials preset and
-# opens the wizard (Sources/Vorssaint/Core/FeaturePresets.swift).
+# resolves its domain from the effective user, so a naive seed there would
+# configure root's Vorssaint rather than the one with a menu bar. That much is
+# only half an argument, and worth being honest about: nix-darwin's own
+# `system.defaults` path solves exactly this with
+# `launchctl asuser … sudo --user=…`, and so could a postActivation block.
 #
-# Its one cost: on a fresh host the agent can bootstrap before Homebrew has
-# installed the cask. The seed still lands (the domain needs no app), and the
-# `open` fails into ~/Library/Logs/vorssaint.log until the next activation.
+# The reason it lives here anyway is ordering. A launchd user agent already
+# runs as the user, and folding the seed and the launch into ONE script makes
+# it impossible for the app to start before its features are chosen — which
+# matters, because a first launch with nothing written runs the app's own
+# Essentials preset and opens the wizard
+# (Sources/Vorssaint/Core/FeaturePresets.swift). The tradeoff is that agents
+# activate before Homebrew, handled just below.
+#
+# Its one cost is ordering: nix-darwin activates user agents BEFORE it runs
+# Homebrew, so on a fresh host the first run finds no app. The script treats
+# that as "not yet" and exits non-zero rather than seeding blind, and the
+# `KeepAlive`/`ThrottleInterval` pair below is what brings it back a few
+# minutes later once the cask has landed. Waiting is not optional: the update-
+# tour markers are read out of the app bundle, so a seed with nothing to read
+# would write the wrong ones.
 #
 # Why `open -g -j -a` and not the inner binary, why RunAtLoad without KeepAlive,
 # and why the app's own launch-at-login toggle stays off: nixos/CLAUDE.md →
@@ -210,6 +231,41 @@
     )
     knownFeatures;
 
+  # Availability is a layer ABOVE each feature's own enable key
+  # (FeatureCatalog.swift, `enabledKeys`): installing a feature makes it appear
+  # in Settings and instantiate its service, but a feature that listens for
+  # something — a wheel event, a window closing, a ⌘X — still checks its own
+  # switch, and every one of those ships off. Seeding availability alone would
+  # hand over five features that are present and do nothing.
+  #
+  # So: for each chosen feature, also switch on what makes it act. The last two
+  # are not `enabledKeys` at all but the shortcut switches for two on-demand
+  # tools, off by default, without which the capture and OCR bindings
+  # (⌃⌥⌘4, ⌃⌥⌘T) are printed in Settings but dead. Everything omitted here —
+  # mixer, keepAwake, the monitors, quickToggles, cleaningMode, uninstaller,
+  # cleaner, homebrew — is on-demand: `enabledKeys` is empty for those, and the
+  # app counts being installed as being engaged.
+  #
+  # Only ever written `true`, and only for chosen features: an unchosen feature
+  # is uninstalled anyway, and writing its switch off would reach past what
+  # this seed is for into settings the hub owns.
+  featureEnableKeys = {
+    autoQuit = "autoQuitEnabled";
+    smoothScroll = "smoothScrollEnabled";
+    # The feature's other key, finderPasteImageAsFile (paste an image as a PNG),
+    # is a second behavior rather than the ⌘X/⌘V this is here for. `enabledKeys`
+    # is an any-of, so the one below is what engages the feature.
+    finderCutPaste = "finderCutPasteEnabled";
+    shelf = "shelfEnabled";
+    urlCleaner = "urlCleanerEnabled";
+    screenshot = "screenshotShortcutEnabled";
+    screenOCR = "screenOCRShortcutEnabled";
+  };
+
+  enableWrites = lib.concatMapStringsSep "\n" (
+    feature: "  /usr/bin/defaults write \"$DOMAIN\" ${featureEnableKeys.${feature}} -bool true"
+  ) (builtins.filter (feature: featureEnableKeys ? ${feature}) cfg.features);
+
   # Only ever reaches ~/Library/Logs/vorssaint.log, but it is the one place a
   # host says out loud which set it came up with.
   chosen =
@@ -308,11 +364,25 @@ in {
 
     launchd.user.agents.vorssaint = {
       script = ''
-        # `set -u` and nothing more: nix-darwin's shell for a launchd script is
-        # not guaranteed to be bash, and there is nothing here to pipefail.
-        set -u
+        # `set -e` matters more than it looks: without it a `defaults write`
+        # that fails part way through still falls through to the `hasOnboarded`
+        # write at the end, marking a half-seeded Mac as done forever.
+        set -eu
 
         DOMAIN="${domain}"
+        APP="/Applications/Vorssaint.app"
+
+        # Do nothing at all until the cask has landed. nix-darwin activates user
+        # agents BEFORE it runs Homebrew, so on a fresh host this is the first
+        # run's normal outcome, not an error. Seeding anyway would be worse than
+        # waiting: the version markers below are read out of the bundle, so a
+        # seed with no app to read would write the wrong ones and let the update
+        # tour through on the very launch this exists to keep clean. Exiting
+        # non-zero is what gets us called again — see KeepAlive below.
+        if [ ! -d "$APP" ]; then
+          echo "vorssaint: $APP is not installed yet, retrying later"
+          exit 1
+        fi
 
         # `hasOnboarded` is the app's own "setup is finished" marker. Absent (a
         # Mac that has never run it) or false is the only state we write in.
@@ -323,27 +393,67 @@ in {
 
         ${featureWrites}
 
+        ${enableWrites}
+
+          # Setting `hasOnboarded` behind the app's back skips the setup wizard
+          # but lands on the other branch of its first-launch check, which is
+          # the post-UPDATE path: a release-notes tour and a support ask whose
+          # window deliberately has no close button. The app's own
+          # markOnboardingComplete() suppresses all three for a clean install;
+          # this does the same by hand.
+          #
+          # Each is gated on `appVersion == <a constant compiled into that
+          # build> && lastSeen != <same constant>`, so writing the running
+          # version into `lastSeen` makes both readings false whatever the
+          # version is — no release number to keep up to date here, and a
+          # genuine tour after a genuine future update still shows, because
+          # this whole block only ever runs once.
+          VERSION="$(/usr/bin/defaults read "$APP/Contents/Info" CFBundleShortVersionString)"
+          for KEY in updateHighlightsSeenVersion supportUpdateIntroVersion updateShowcaseIntroVersion; do
+            /usr/bin/defaults write "$DOMAIN" "$KEY" -string "$VERSION"
+          done
+
           # The in-app launch-at-login toggle registers an SMAppService login
           # item that nix neither owns nor can assert, and the agent this script
           # runs from already does the job. Pin it off so the two never both
           # register. See nixos/CLAUDE.md → "Launching GUI apps at login".
           /usr/bin/defaults write "$DOMAIN" launchAtLoginWanted -bool false
 
-          # Last, deliberately: it is the marker that stops the next run. An
-          # interrupted seed leaves it unset and simply redoes the whole thing.
+          # Last, deliberately: it is the marker that stops the next run. A seed
+          # that dies before here leaves it unset and simply redoes the whole
+          # thing.
           /usr/bin/defaults write "$DOMAIN" hasOnboarded -bool true
         fi
 
         # `open` on a running app just activates it, so this is safe to re-run
         # on every activation. -g = don't steal focus, -j = launch hidden.
-        exec /usr/bin/open -g -j -a /Applications/Vorssaint.app
+        exec /usr/bin/open -g -j -a "$APP"
       '';
 
       serviceConfig = {
         RunAtLoad = true;
-        # Where "Unable to find application named 'Vorssaint'" shows up if the
-        # cask hasn't installed yet on a fresh host, and where the seed reports
-        # whether it ran.
+
+        # The one place this departs from ./ice.nix and ./handy.nix, and it is
+        # narrower than the "never KeepAlive" those two carry. What that rule
+        # forbids is a bare `KeepAlive = true`, which reads `open`'s immediate
+        # exit as a crash and respawns for ever. `SuccessfulExit = false` is the
+        # opposite: retry only while the script FAILS, which here means only
+        # while the cask is missing. The moment Homebrew installs it the seed
+        # runs, `open` succeeds, and the job stops being restarted.
+        #
+        # It is needed because the alternative recovery does not exist.
+        # nix-darwin only reloads a user agent when its generated plist differs
+        # from the installed one, so an unchanged config means the agent is
+        # never re-bootstrapped and RunAtLoad never fires again: without this,
+        # a fresh host whose first activation ran before Homebrew would stay
+        # unseeded until the next login, and `just dr` would not fix it.
+        KeepAlive = {
+          SuccessfulExit = false;
+        };
+        ThrottleInterval = 300;
+
+        # Where the seed says whether it ran, which set it wrote, or that it is
+        # still waiting on the cask.
         StandardOutPath = "/Users/${user}/Library/Logs/vorssaint.log";
         StandardErrorPath = "/Users/${user}/Library/Logs/vorssaint.log";
       };

--- a/nixos/modules/darwin/vorssaint.nix
+++ b/nixos/modules/darwin/vorssaint.nix
@@ -54,35 +54,38 @@
 # does not re-seed; `brew uninstall --zap --cask vorssaint` is the one that
 # takes the plist with it.
 #
-# ## Why the seed lives in the launchd agent rather than postActivation
+# ## Why the seed runs in postActivation and not in the login agent
 #
-# `system.activationScripts.postActivation` runs as root, and `defaults write`
-# resolves its domain from the effective user, so a naive seed there would
-# configure root's Vorssaint rather than the one with a menu bar. That much is
-# only half an argument, and worth being honest about: nix-darwin's own
-# `system.defaults` path solves exactly this with
-# `launchctl asuser … sudo --user=…`, and so could a postActivation block.
+# It ran in the agent first, and moria proved that wrong on its first deploy —
+# worth writing down, because the failure is invisible until it has already
+# cost you the one chance the seed gets.
 #
-# The reason it lives here anyway is ordering. A launchd user agent already
-# runs as the user, and folding the seed and the launch into ONE script makes
-# it impossible for the app to start before its features are chosen — which
-# matters, because a first launch with nothing written runs the app's own
-# Essentials preset and opens the wizard
-# (Sources/Vorssaint/Core/FeaturePresets.swift). The tradeoff is that agents
-# activate before Homebrew, handled just below.
+# nix-darwin's activation order (modules/system/activation-scripts.nix) is:
+# user agents, then Homebrew, then postActivation. So an agent-hosted seed
+# always fires on a Mac where the cask has not been installed yet, and every
+# option from there is bad. Seeding blind is wrong on its own terms: the
+# update-tour markers below are read out of the app bundle, so there is
+# nothing to read. Waiting and retrying — what this did — leaves a window
+# between `just dr` finishing and the retry in which the app is installed,
+# unconfigured, and one click away in Spotlight. Whoever opens it gets the
+# wizard, and the wizard sets `hasOnboarded` itself, so the seed is locked out
+# for good. A seed that only gets one chance must not spend it racing a human.
 #
-# Its one cost is ordering: nix-darwin activates user agents BEFORE it runs
-# Homebrew, so on a fresh host the first run finds no app. The script treats
-# that as "not yet" and exits non-zero rather than seeding blind, and the
-# `KeepAlive`/`ThrottleInterval` pair below is what brings it back a few
-# minutes later once the cask has landed. Waiting is not optional: the update-
-# tour markers are read out of the app bundle, so a seed with nothing to read
-# would write the wrong ones.
+# postActivation has none of that: Homebrew has already run, and the person who
+# typed `just dr` is still watching it finish.
 #
-# Why `open -g -j -a` and not the inner binary, why RunAtLoad without KeepAlive,
-# and why the app's own launch-at-login toggle stays off: nixos/CLAUDE.md →
-# "Launching GUI apps at login". This is the third user of that pattern, after
-# ./ice.nix and ./handy.nix; it is the only one that also writes preferences.
+# The root objection to postActivation is real but solved upstream — activation
+# runs as root and `defaults` resolves its domain from the effective user, so
+# an unwrapped write configures root's Vorssaint. nix-darwin's own
+# `system.defaults` path answers it with
+# `launchctl asuser "$(id -u -- user)" sudo --user=user --`
+# (modules/system/defaults-write.nix), and that is exactly what is copied here.
+#
+# What is left in the agent is only the launch, in the plain shape ./ice.nix
+# and ./handy.nix use. Why `open -g -j -a` and not the inner binary, why
+# RunAtLoad without KeepAlive, and why the app's own launch-at-login toggle
+# stays off: nixos/CLAUDE.md → "Launching GUI apps at login". This is that
+# pattern's third user, and it needs no exception to it.
 #
 # ## Permissions are still manual
 #
@@ -137,6 +140,7 @@
 {
   config,
   lib,
+  pkgs,
   vars,
   ...
 }: let
@@ -268,6 +272,71 @@
 
   # Only ever reaches ~/Library/Logs/vorssaint.log, but it is the one place a
   # host says out loud which set it came up with.
+  userArg = lib.escapeShellArg user;
+
+  # Runs AS THE USER — see the postActivation block below for how, and why it
+  # is not in the login agent.
+  seedScript = pkgs.writeShellScript "vorssaint-seed" ''
+    # `set -e` matters more than it looks: without it a `defaults write` that
+    # fails part way through still falls through to the `hasOnboarded` write at
+    # the end, marking a half-seeded Mac as done for ever.
+    set -eu
+
+    DOMAIN="${domain}"
+    APP="/Applications/Vorssaint.app"
+
+    # Reached only after Homebrew has run, so a missing app means the cask
+    # failed rather than "not yet". Nothing to do, and not our error to raise.
+    if [ ! -d "$APP" ]; then
+      echo "vorssaint: $APP is not installed, skipping the seed"
+      exit 0
+    fi
+
+    # `hasOnboarded` is the app's own "setup is finished" marker. Absent (a Mac
+    # that has never run it) or false is the only state we write in — so a hub
+    # you have since curated by hand is never overwritten.
+    if [ "$(/usr/bin/defaults read "$DOMAIN" hasOnboarded 2>/dev/null || echo 0)" = "1" ]; then
+      echo "vorssaint: already set up, leaving the Features hub alone"
+    else
+      echo "vorssaint: seeding the Features hub with ${chosen}"
+
+    ${featureWrites}
+
+    ${enableWrites}
+
+      # Setting `hasOnboarded` behind the app's back skips the setup wizard but
+      # lands on the other branch of its first-launch check, which is the post-
+      # UPDATE path: a release-notes tour and a support ask whose window
+      # deliberately has no close button. The app's own markOnboardingComplete()
+      # suppresses all three for a clean install; this does the same by hand.
+      #
+      # Each is gated on `appVersion == <a constant compiled into that build> &&
+      # lastSeen != <same constant>`, so writing the running version into
+      # `lastSeen` makes both readings false whatever the version is — no
+      # release number to keep up to date here, and a genuine tour after a
+      # genuine future update still shows, because this only ever runs once.
+      VERSION="$(/usr/bin/defaults read "$APP/Contents/Info" CFBundleShortVersionString)"
+      for KEY in updateHighlightsSeenVersion supportUpdateIntroVersion updateShowcaseIntroVersion; do
+        /usr/bin/defaults write "$DOMAIN" "$KEY" -string "$VERSION"
+      done
+
+      # The in-app launch-at-login toggle registers an SMAppService login item
+      # that nix neither owns nor can assert, and the agent below already does
+      # the job. Pin it off so the two never both register. See nixos/CLAUDE.md
+      # → "Launching GUI apps at login".
+      /usr/bin/defaults write "$DOMAIN" launchAtLoginWanted -bool false
+
+      # Last, deliberately: it is the marker that stops the next run. A seed
+      # that dies before here leaves it unset and simply redoes the whole thing.
+      /usr/bin/defaults write "$DOMAIN" hasOnboarded -bool true
+    fi
+
+    # So a fresh `just dr` ends with the app running and configured, rather than
+    # configured but not visible until the next login. Idempotent: `open` on a
+    # running app just activates it, and -g/-j keep it quiet and hidden.
+    exec /usr/bin/open -g -j -a "$APP"
+  '';
+
   chosen =
     if cfg.features == []
     then "nothing"
@@ -362,98 +431,46 @@ in {
   config = lib.mkIf cfg.enable {
     homebrew.casks = ["vorssaint"];
 
+    # Seed the Features hub here, and NOT from the login agent below, because
+    # ordering is the whole problem. nix-darwin's activation runs
+    # `userLaunchd` (agents) BEFORE `homebrew`, and `postActivation` after it
+    # — modules/system/activation-scripts.nix, in that order. A seed in the
+    # agent therefore fires on a Mac with no app yet, and whatever it does
+    # next is a race: launch the app unseeded, or wait and retry and lose to
+    # whoever opens Vorssaint first. Losing that race is permanent, because
+    # the wizard sets `hasOnboarded` itself and the seed never runs again.
+    #
+    # From here the cask is already installed and the human is still watching
+    # `just dr` finish, so there is no race left to lose.
+    #
+    # `launchctl asuser … sudo --user=…` is nix-darwin's own idiom for this
+    # (modules/system/defaults-write.nix): activation runs as root, and
+    # `defaults` resolves its domain from the effective user, so an unwrapped
+    # write would configure root's Vorssaint rather than the one with a menu
+    # bar.
+    #
+    # Never fatal. The activation script runs under `set -e`, and a Mac that
+    # cannot be seeded — no GUI session to attach to, Homebrew failed earlier
+    # — is not a reason to fail the whole rebuild. The app just shows its own
+    # wizard, which is exactly where this started.
+    system.activationScripts.postActivation.text = lib.mkAfter ''
+      if ! launchctl asuser "$(id -u -- ${userArg})" sudo --user=${userArg} -- ${seedScript}; then
+        echo "WARNING: the Vorssaint seed did not finish (see above)." >&2
+        echo "         Vorssaint will show its own setup wizard on first launch." >&2
+      fi
+    '';
+
+    # Plain ./ice.nix shape, now that the seed has moved out: RunAtLoad, no
+    # KeepAlive, `open -a` rather than the inner binary. See nixos/CLAUDE.md →
+    # "Launching GUI apps at login" for why each of those.
     launchd.user.agents.vorssaint = {
-      script = ''
-        # `set -e` matters more than it looks: without it a `defaults write`
-        # that fails part way through still falls through to the `hasOnboarded`
-        # write at the end, marking a half-seeded Mac as done forever.
-        set -eu
-
-        DOMAIN="${domain}"
-        APP="/Applications/Vorssaint.app"
-
-        # Do nothing at all until the cask has landed. nix-darwin activates user
-        # agents BEFORE it runs Homebrew, so on a fresh host this is the first
-        # run's normal outcome, not an error. Seeding anyway would be worse than
-        # waiting: the version markers below are read out of the bundle, so a
-        # seed with no app to read would write the wrong ones and let the update
-        # tour through on the very launch this exists to keep clean. Exiting
-        # non-zero is what gets us called again — see KeepAlive below.
-        if [ ! -d "$APP" ]; then
-          echo "vorssaint: $APP is not installed yet, retrying later"
-          exit 1
-        fi
-
-        # `hasOnboarded` is the app's own "setup is finished" marker. Absent (a
-        # Mac that has never run it) or false is the only state we write in.
-        if [ "$(/usr/bin/defaults read "$DOMAIN" hasOnboarded 2>/dev/null || echo 0)" = "1" ]; then
-          echo "vorssaint: already set up, leaving the Features hub alone"
-        else
-          echo "vorssaint: seeding the Features hub with ${chosen}"
-
-        ${featureWrites}
-
-        ${enableWrites}
-
-          # Setting `hasOnboarded` behind the app's back skips the setup wizard
-          # but lands on the other branch of its first-launch check, which is
-          # the post-UPDATE path: a release-notes tour and a support ask whose
-          # window deliberately has no close button. The app's own
-          # markOnboardingComplete() suppresses all three for a clean install;
-          # this does the same by hand.
-          #
-          # Each is gated on `appVersion == <a constant compiled into that
-          # build> && lastSeen != <same constant>`, so writing the running
-          # version into `lastSeen` makes both readings false whatever the
-          # version is — no release number to keep up to date here, and a
-          # genuine tour after a genuine future update still shows, because
-          # this whole block only ever runs once.
-          VERSION="$(/usr/bin/defaults read "$APP/Contents/Info" CFBundleShortVersionString)"
-          for KEY in updateHighlightsSeenVersion supportUpdateIntroVersion updateShowcaseIntroVersion; do
-            /usr/bin/defaults write "$DOMAIN" "$KEY" -string "$VERSION"
-          done
-
-          # The in-app launch-at-login toggle registers an SMAppService login
-          # item that nix neither owns nor can assert, and the agent this script
-          # runs from already does the job. Pin it off so the two never both
-          # register. See nixos/CLAUDE.md → "Launching GUI apps at login".
-          /usr/bin/defaults write "$DOMAIN" launchAtLoginWanted -bool false
-
-          # Last, deliberately: it is the marker that stops the next run. A seed
-          # that dies before here leaves it unset and simply redoes the whole
-          # thing.
-          /usr/bin/defaults write "$DOMAIN" hasOnboarded -bool true
-        fi
-
-        # `open` on a running app just activates it, so this is safe to re-run
-        # on every activation. -g = don't steal focus, -j = launch hidden.
-        exec /usr/bin/open -g -j -a "$APP"
-      '';
-
+      command = "/usr/bin/open -g -j -a /Applications/Vorssaint.app";
       serviceConfig = {
         RunAtLoad = true;
-
-        # The one place this departs from ./ice.nix and ./handy.nix, and it is
-        # narrower than the "never KeepAlive" those two carry. What that rule
-        # forbids is a bare `KeepAlive = true`, which reads `open`'s immediate
-        # exit as a crash and respawns for ever. `SuccessfulExit = false` is the
-        # opposite: retry only while the script FAILS, which here means only
-        # while the cask is missing. The moment Homebrew installs it the seed
-        # runs, `open` succeeds, and the job stops being restarted.
-        #
-        # It is needed because the alternative recovery does not exist.
-        # nix-darwin only reloads a user agent when its generated plist differs
-        # from the installed one, so an unchanged config means the agent is
-        # never re-bootstrapped and RunAtLoad never fires again: without this,
-        # a fresh host whose first activation ran before Homebrew would stay
-        # unseeded until the next login, and `just dr` would not fix it.
-        KeepAlive = {
-          SuccessfulExit = false;
-        };
-        ThrottleInterval = 300;
-
-        # Where the seed says whether it ran, which set it wrote, or that it is
-        # still waiting on the cask.
+        # Where "Unable to find application named 'Vorssaint'" shows up if the
+        # cask hasn't installed yet on a fresh host — the agent is bootstrapped
+        # before Homebrew runs, so that is the normal first-deploy outcome and
+        # the postActivation seed above is what launches it that time round.
         StandardOutPath = "/Users/${user}/Library/Logs/vorssaint.log";
         StandardErrorPath = "/Users/${user}/Library/Logs/vorssaint.log";
       };

--- a/nixos/modules/darwin/vorssaint.nix
+++ b/nixos/modules/darwin/vorssaint.nix
@@ -94,49 +94,63 @@
 # ../../docs/darwin-post-deploy.md. Features that need a grant simply sit inert
 # until it is given, so a half-configured host is quiet rather than broken.
 #
-# ## Conflicts with what these Macs already run
+# ## Overlap with what these Macs already run
 #
-# Vorssaint's feature list is wide enough to collide with four things already
-# deployed here. Three of the collisions are settled by simply not installing
-# the feature — an uninstalled feature does not merely sit idle, it never
-# instantiates its service — so they cost nothing but need to stay uninstalled:
+# Vorssaint is wide enough to reach into four things already deployed here.
+# The list below does not dodge all of them, and that is a choice made at the
+# machine rather than an oversight — worth knowing before reading it as an
+# accident:
 #
-#   * `superKey` reimplements the Caps Lock hold this repo already does in
-#     ../../../dot/karabiner (macOS) and ../common/keyd.nix (NixOS): hold for a
-#     modifier, tap for Escape. Two event taps grabbing the same key is the one
-#     conflict here that is genuinely broken rather than merely redundant.
-#   * `switcher`, `windowLayout`, `windowMaximizer`, `dockPreview` and
-#     `dockClick` are a window manager, and the `aerospace` cask is already the
-#     window manager. Edge snapping and drag-to-move in particular fight tiling.
-#   * `commandBar`, `quickLauncher`, `clipboardHistory` and `textSnippets`
-#     duplicate the `raycast` cask, down to competing for global shortcuts.
+#   * `switcher` and `dockPreview` overlap the `aerospace` cask. AeroSpace
+#     tiles; these replace ⌘Tab and add Dock hover previews, which is a
+#     different job, so they coexist. The tiling-hostile half of Vorssaint —
+#     `windowLayout` (edge snapping, drag-to-move) and `windowMaximizer` — is
+#     the part left out.
+#   * `commandBar` and `clipboardHistory` overlap the `raycast` cask outright.
+#     See the shortcut note below; this is the overlap most likely to bite.
+#   * The `monitor*` features overlap the `stats` cask. Both put CPU, GPU,
+#     memory, network and battery readouts in the menu bar, so this is two sets
+#     of samplers for one set of numbers. If Vorssaint's version earns its
+#     place — it carries the speed test, disk health and battery power draw in
+#     the same panel — dropping `stats` from ./homebrew-base.nix is the
+#     follow-up.
 #
-# The fourth is a real choice rather than an obvious no: the `monitor*` features
-# below overlap the `stats` cask in ./homebrew-base.nix. Both put CPU, GPU,
-# memory, network and battery readouts in the menu bar, and running both means
-# two sets of samplers for one set of numbers. They are enabled here because
-# Vorssaint's version carries the speed test, disk health and battery power draw
-# in the same panel — but if they earn their place, dropping `stats` from
-# ./homebrew-base.nix is the follow-up, and if they do not, delete the six ids.
+# `superKey` is the one genuine incompatibility and stays out for good. It
+# reimplements the Caps Lock hold this repo already does in
+# ../../../dot/karabiner (macOS) and ../common/keyd.nix (NixOS): hold for a
+# modifier, tap for Escape. Two event taps grabbing one key is broken rather
+# than merely redundant.
 #
-# `scrollInverter` is the subtle one, and it is deliberately absent. Its whole
-# purpose is to invert the wheel for a mouse *only*, leaving natural scrolling
-# on for the trackpad. But ./common.nix sets
+# ## The one shortcut this deliberately leaves off
+#
+# `commandBar` is installed but its shortcut is NOT switched on, and it is the
+# only chosen feature treated that way. Its default binding is ⌥Space, which is
+# also Raycast's default hotkey — turning it on from here would quietly take
+# over the launcher key on both Macs. The bar still opens from the menu panel,
+# and picking a combination for it is a decision to make in Settings with
+# Raycast's own binding in view. Everything else that needed switching on got
+# switched on; see `featureEnableKeys`.
+#
+# `scrollInverter` is absent for a different reason, and it is the subtle one.
+# Its whole purpose is to invert the wheel for a mouse *only*, leaving natural
+# scrolling on for the trackpad. But ./common.nix sets
 # `NSGlobalDomain."com.apple.swipescrolldirection" = false`, which already
 # inverts both, so adding the feature on top would invert the mouse twice and
 # hand back exactly the behavior it exists to fix. To adopt it properly, flip
 # that global back to `true` (trackpad returns to natural scrolling) and add
-# "scrollInverter" to the list below in the same commit — one or the other
-# alone is a regression.
+# "scrollInverter" to the list in the same commit — one or the other alone is
+# a regression.
 #
 # ## Where the feature list came from
 #
-# The default below is the set https://youtu.be/s8dzlv4WuNk singles out as the
-# ones actually worth having after a month of use, minus the two that video
-# tried and did not keep (`commandBar`, `quickLauncher`) and minus the conflicts
-# above. It is a starting point, not a verdict: the hub is one click
-# per feature, and this list is only ever read on a Mac that has never run the
-# app.
+# It started as the set https://youtu.be/s8dzlv4WuNk singles out after a month
+# of use. It is now moria's actual hub, read back off the machine after that
+# host was set up by hand, so citadel comes up matching moria rather than
+# matching a video. Two things changed in that trip worth noticing if you are
+# reconsidering the list: `keepAwake` — the video's headline feature, closing
+# the lid on an external display without the charger — is NOT in it, and
+# neither are `uninstaller`, `cleaner` or `homebrew`.
+#
 {
   config,
   lib,
@@ -254,16 +268,31 @@
   # is uninstalled anyway, and writing its switch off would reach past what
   # this seed is for into settings the hub owns.
   featureEnableKeys = {
+    # `enabledKeys`: without these the feature is installed and does nothing.
     autoQuit = "autoQuitEnabled";
-    smoothScroll = "smoothScrollEnabled";
-    # The feature's other key, finderPasteImageAsFile (paste an image as a PNG),
-    # is a second behavior rather than the ⌘X/⌘V this is here for. `enabledKeys`
-    # is an any-of, so the one below is what engages the feature.
-    finderCutPaste = "finderCutPasteEnabled";
+    brightness = "brightnessControlEnabled";
+    clipboardHistory = "clipboardHistoryEnabled";
+    dockPreview = "dockPreviewEnabled";
+    pastePlain = "pastePlainEnabled";
     shelf = "shelfEnabled";
+    smoothScroll = "smoothScrollEnabled";
     urlCleaner = "urlCleanerEnabled";
+    # Already ships on; written anyway so the seed describes the host outright
+    # rather than by agreeing with a default that could change.
+    switcher = "switcherEnabled";
+    # The feature's other key, finderPasteImageAsFile (paste an image as a
+    # PNG), is a second behavior rather than the ⌘X/⌘V this is here for.
+    # `enabledKeys` is an any-of, so the one below is what engages it.
+    finderCutPaste = "finderCutPasteEnabled";
+
+    # Not `enabledKeys` — these tools work from the menu panel regardless. They
+    # are here because a capture tool you cannot reach from the keyboard is
+    # most of a capture tool missing, and all four default onto the free ⌃⌥⌘
+    # layer, which nothing else here uses.
     screenshot = "screenshotShortcutEnabled";
     screenOCR = "screenOCRShortcutEnabled";
+    screenRecorder = "recorderShortcutEnabled";
+    cameraPreview = "cameraPreviewShortcutEnabled";
   };
 
   enableWrites = lib.concatMapStringsSep "\n" (
@@ -351,70 +380,46 @@ in {
     features = lib.mkOption {
       type = lib.types.listOf (lib.types.enum knownFeatures);
       default = [
-        # Sound. Per-app volume, and per-app *output* with it: music out of the
-        # speakers while a call or an editor stays in the headphones. macOS has
-        # no equivalent at all. Wants the System Audio Recording grant.
+        # Sound. Per-app volume and per-app output; macOS has no equivalent.
         "mixer"
 
-        # Stay awake with the lid closed. The reason clamshell mode works on
-        # battery instead of sleeping the moment the charger comes out --
-        # `caffeinate` keeps the Mac up but drops the external display.
-        "keepAwake"
-
-        # Give a mouse wheel trackpad-style glide. Note the deliberate absence
-        # of "scrollInverter" beside it: see the header's conflicts section, it
-        # would double-invert against this repo's own global setting.
-        "smoothScroll"
-
-        # Capture and OCR, both on the free control-option-command layer
-        # (screenshot on 4, text-from-screen on T), so macOS keeps its own
-        # command-shift-3/4/5 and screencapture.location in ./common.nix stands.
-        "screenshot"
-        "screenOCR"
-
-        # command-X then command-V moves a file in Finder, instead of the
-        # command-option-V that nothing outside macOS uses.
-        "finderCutPaste"
-
-        # Closing the last window quits the app, for the handful (Obsidian,
-        # Notes, browsers) that otherwise linger with no window at all.
+        # Windows and Dock. `switcher` is the one to know about: its enable key
+        # ships ON and its default binding is ⌘Tab, so installing it replaces
+        # the system app switcher rather than sitting beside it.
+        "switcher"
+        "dockPreview"
         "autoQuit"
 
-        # System monitor, one id per metric family. OVERLAPS the `stats` cask in
-        # ./homebrew-base.nix — see the header's conflicts section before
-        # deciding which of the two keeps the menu bar.
+        # Clipboard and files. `pastePlain` binds ⇧⌥⌘V, the same combination
+        # macOS uses for Paste and Match Style, deliberately — it does the same
+        # job everywhere rather than only where an app implements it.
+        "clipboardHistory"
+        "pastePlain"
+        "finderCutPaste"
+        "urlCleaner"
+
+        # Display. Brightness for external screens over their own control
+        # channel, which the keyboard keys do not reach.
+        "brightness"
+
+        # Capture and tools. The three capture tools share one selector and sit
+        # on the free ⌃⌥⌘ layer (4, T, 5), so macOS keeps ⌘⇧3/4/5 and the
+        # screencapture.location in ./common.nix still stands.
+        "screenshot"
+        "screenOCR"
+        "screenRecorder"
+        "cameraPreview"
+        "mediaTools"
+        "commandBar"
+
+        # System monitor, one id per metric family. Overlaps the `stats` cask
+        # in ./homebrew-base.nix — see the header's conflicts section.
         "monitorCPU"
         "monitorGPU"
         "monitorMemory"
         "monitorNetwork"
         "monitorDisk"
         "monitorPower"
-
-        # One-click system actions: light/dark, keyboard backlight, empty the
-        # Trash, eject every disk. Wants the Finder automation grant.
-        "quickToggles"
-
-        # Lock the keyboard and black out the displays to wipe them down.
-        "cleaningMode"
-
-        # Removal and leftovers. `uninstaller` takes an app's caches, prefs and
-        # helpers with it; `cleaner` sweeps what a normal drag-to-Trash left
-        # behind. Both reach further with the optional Full Disk Access grant.
-        "uninstaller"
-        "cleaner"
-
-        # Homebrew formulae and casks without a terminal. Read-mostly here --
-        # ./homebrew-base.nix is authoritative for anything that should survive
-        # a rebuild, and `onActivation.cleanup = "none"` means a cask installed
-        # by hand through this pane simply persists undeclared.
-        "homebrew"
-
-        # Strip tracking parameters from copied links.
-        "urlCleaner"
-
-        # A floating shelf to park files mid-drag and drop them somewhere else
-        # later, instead of holding a drag across a window switch.
-        "shelf"
       ];
       description = ''
         Features to install on a fresh host. Everything omitted is written off,

--- a/nixos/modules/darwin/vorssaint.nix
+++ b/nixos/modules/darwin/vorssaint.nix
@@ -1,0 +1,352 @@
+# Vorssaint — one menu bar app in place of a dozen small Mac utilities.
+#
+# https://github.com/vorssaint/vorssaint-utils (GPL-3.0-or-later, Swift, bundle
+# id com.vorssaint.utils). Installed from the `vorssaint` cask: arm64 + macOS 14
+# only, which every Mac here satisfies, and Developer-ID signed + notarized.
+#
+# This module does three things, and each is enabled per host by importing it
+# and setting `services.vorssaint.enable`:
+#   1. adds the cask (nix-darwin concatenates it onto the host's casks list),
+#   2. launches the app at login with the usual `open -a` agent,
+#   3. seeds the Features hub ONCE, so a fresh host comes up with the feature
+#      set below already chosen instead of the app's own setup wizard.
+#
+# ## Why (3) is a seed and not a declarative `system.defaults` block
+#
+# Vorssaint has no config file. The Features hub is GUI-only, and its "export
+# settings" writes a plist through an NSSavePanel — there is no CLI, no watched
+# file and no import flag. What it *does* have is an ordinary UserDefaults
+# domain: one boolean per feature, `featureAvailable.<id>`, where the ids are
+# the AppFeature raw values (Sources/Vorssaint/Core/FeatureCatalog.swift).
+#
+# So the keys could go straight into `system.defaults.CustomUserPreferences` and
+# be rewritten on every `just dr`. They deliberately are not, for two reasons:
+#
+#   * The app owns this state at runtime. Every toggle in the Features hub, and
+#     every preset button, writes these same keys. Enforcing them on activation
+#     would silently undo anything flipped in the GUI — the same reason oMLX's
+#     downloaded models and CrossOver's bottles are left to their apps.
+#   * Availability is only read at launch. A mid-session rewrite would not take
+#     effect until a relaunch anyway (the app relaunches itself after its own
+#     settings import for exactly this reason), so "declarative" would buy a
+#     value that disagrees with what is on screen.
+#
+# The seed is gated on `hasOnboarded`, which the app itself sets the moment
+# setup finishes. So it fires exactly once per Mac — on the first activation
+# after the cask lands — and never fights the hub afterwards. To re-seed a host
+# deliberately (say, after changing the list below), clear the marker and let
+# the agent re-run:
+#
+#   defaults delete com.vorssaint.utils hasOnboarded
+#   launchctl kickstart -k "gui/$(id -u)/org.nixos.vorssaint"
+#
+# Note that `brew uninstall --cask vorssaint` deletes the whole preferences
+# plist, which clears `hasOnboarded` too — so a reinstall re-seeds on its own.
+#
+# ## Why the seed lives in the launchd agent rather than postActivation
+#
+# `system.activationScripts.postActivation` runs as root, and `defaults write`
+# resolves its domain from the effective user: seeding there would configure
+# root's Vorssaint, not the one with a menu bar. A launchd *user* agent already
+# runs as the user, in their GUI session, so cfprefsd sees the writes. Folding
+# the seed and the launch into one script also fixes the ordering for free —
+# the app can never start before its features are chosen, which matters because
+# a first launch with nothing written runs the app's own Essentials preset and
+# opens the wizard (Sources/Vorssaint/Core/FeaturePresets.swift).
+#
+# Its one cost: on a fresh host the agent can bootstrap before Homebrew has
+# installed the cask. The seed still lands (the domain needs no app), and the
+# `open` fails into ~/Library/Logs/vorssaint.log until the next activation.
+#
+# Why `open -g -j -a` and not the inner binary, why RunAtLoad without KeepAlive,
+# and why the app's own launch-at-login toggle stays off: nixos/CLAUDE.md →
+# "Launching GUI apps at login". This is the third user of that pattern, after
+# ./ice.nix and ./handy.nix; it is the only one that also writes preferences.
+#
+# ## Permissions are still manual
+#
+# Nothing here can grant TCC. Accessibility and Screen Recording are clicked
+# through by hand per host exactly like Ice and Handy — see
+# ../../docs/darwin-post-deploy.md. Features that need a grant simply sit inert
+# until it is given, so a half-configured host is quiet rather than broken.
+#
+# ## Conflicts with what these Macs already run
+#
+# Vorssaint's feature list is wide enough to collide with four things already
+# deployed here. Three of the collisions are settled by simply not installing
+# the feature — an uninstalled feature does not merely sit idle, it never
+# instantiates its service — so they cost nothing but need to stay uninstalled:
+#
+#   * `superKey` reimplements the Caps Lock hold this repo already does in
+#     ../../../dot/karabiner (macOS) and ../common/keyd.nix (NixOS): hold for a
+#     modifier, tap for Escape. Two event taps grabbing the same key is the one
+#     conflict here that is genuinely broken rather than merely redundant.
+#   * `switcher`, `windowLayout`, `windowMaximizer`, `dockPreview` and
+#     `dockClick` are a window manager, and the `aerospace` cask is already the
+#     window manager. Edge snapping and drag-to-move in particular fight tiling.
+#   * `commandBar`, `quickLauncher`, `clipboardHistory` and `textSnippets`
+#     duplicate the `raycast` cask, down to competing for global shortcuts.
+#
+# The fourth is a real choice rather than an obvious no: the `monitor*` features
+# below overlap the `stats` cask in ./homebrew-base.nix. Both put CPU, GPU,
+# memory, network and battery readouts in the menu bar, and running both means
+# two sets of samplers for one set of numbers. They are enabled here because
+# Vorssaint's version carries the speed test, disk health and battery power draw
+# in the same panel — but if they earn their place, dropping `stats` from
+# ./homebrew-base.nix is the follow-up, and if they do not, delete the six ids.
+#
+# `scrollInverter` is the subtle one, and it is deliberately absent. Its whole
+# purpose is to invert the wheel for a mouse *only*, leaving natural scrolling
+# on for the trackpad. But ./common.nix sets
+# `NSGlobalDomain."com.apple.swipescrolldirection" = false`, which already
+# inverts both, so adding the feature on top would invert the mouse twice and
+# hand back exactly the behavior it exists to fix. To adopt it properly, flip
+# that global back to `true` (trackpad returns to natural scrolling) and add
+# "scrollInverter" to the list below in the same commit — one or the other
+# alone is a regression.
+#
+# ## Where the feature list came from
+#
+# The default below is the set https://youtu.be/s8dzlv4WuNk singles out as the
+# ones actually worth having after a month of use, minus the two that video
+# tried and did not keep (`commandBar`, `quickLauncher`) and minus the conflicts
+# above. It is a starting point, not a verdict: the hub is one click
+# per feature, and this list is only ever read on a Mac that has never run the
+# app.
+{
+  config,
+  lib,
+  vars,
+  ...
+}: let
+  cfg = config.services.vorssaint;
+  user = vars.user.name;
+  domain = "com.vorssaint.utils";
+
+  # Every id the Features hub understands, in the app's own grouping. These are
+  # the raw values of `enum AppFeature` in
+  # Sources/Vorssaint/Core/FeatureCatalog.swift, which its comment promises are
+  # stable ("cases can be added but never renamed") — they are what gets
+  # persisted inside the availability key. Used as the option's enum, so a typo
+  # fails evaluation with the valid list rather than writing a dead key.
+  knownFeatures = [
+    # Windows and Dock
+    "switcher"
+    "dockPreview"
+    "dockClick"
+    "windowMaximizer"
+    "windowLayout"
+    "autoQuit"
+    # Mouse and keyboard
+    "scrollInverter"
+    "focusFollowsMouse"
+    "smoothScroll"
+    "mouseNavigation"
+    "mouseButtonShortcuts"
+    "middleClick"
+    "keyboardDebounce"
+    "textSnippets"
+    "superKey"
+    # Clipboard and files
+    "clipboardHistory"
+    "pastePlain"
+    "finderCutPaste"
+    "finderRename"
+    "shelf"
+    "urlCleaner"
+    "diskImageInstaller"
+    # Sound
+    "mixer"
+    "soundOutputSwitcher"
+    "micMute"
+    "musicBlock"
+    # Energy and display
+    "keepAwake"
+    "brightness"
+    "extraBrightness"
+    "bluetoothSleep"
+    # Tools
+    "quickLauncher"
+    "quickToggles"
+    "colorPicker"
+    "screenOCR"
+    "cleaningMode"
+    "mediaTools"
+    "cleaner"
+    "uninstaller"
+    "homebrew"
+    "appUpdates"
+    "screenshot"
+    "cameraPreview"
+    "radialMenu"
+    "scratchpad"
+    "commandBar"
+    "screenRecorder"
+    "killProcess"
+    # System monitor, one entry per metric family
+    "monitorCPU"
+    "monitorGPU"
+    "monitorMemory"
+    "monitorNetwork"
+    "monitorDisk"
+    "monitorPower"
+    "fanControl"
+  ];
+
+  # Write EVERY id, not just the chosen ones. The off writes are what make the
+  # seed total: without them an unlisted feature falls back to whatever the app
+  # registered as its default, so the list below would describe the host only
+  # by accident. This mirrors the app's own first-run pass.
+  #
+  # A plain string, not an indented one, and the two leading spaces are on
+  # purpose: this lands inside the seed script's `else` branch, and nix strips
+  # an indented string's indentation at parse time — before interpolation ever
+  # happens — so the alignment has to be part of the value or it is lost.
+  featureWrites =
+    lib.concatMapStringsSep "\n" (
+      feature:
+        "  /usr/bin/defaults write \"$DOMAIN\" featureAvailable.${feature} -bool "
+        + lib.boolToString (builtins.elem feature cfg.features)
+    )
+    knownFeatures;
+
+  # Only ever reaches ~/Library/Logs/vorssaint.log, but it is the one place a
+  # host says out loud which set it came up with.
+  chosen =
+    if cfg.features == []
+    then "nothing"
+    else lib.concatStringsSep ", " cfg.features;
+in {
+  options.services.vorssaint = {
+    enable = lib.mkEnableOption ''
+      Vorssaint on this Darwin host: the cask, an `open -a` login agent, and a
+      one-time seed of the Features hub from `services.vorssaint.features`
+    '';
+
+    features = lib.mkOption {
+      type = lib.types.listOf (lib.types.enum knownFeatures);
+      default = [
+        # Sound. Per-app volume, and per-app *output* with it: music out of the
+        # speakers while a call or an editor stays in the headphones. macOS has
+        # no equivalent at all. Wants the System Audio Recording grant.
+        "mixer"
+
+        # Stay awake with the lid closed. The reason clamshell mode works on
+        # battery instead of sleeping the moment the charger comes out --
+        # `caffeinate` keeps the Mac up but drops the external display.
+        "keepAwake"
+
+        # Give a mouse wheel trackpad-style glide. Note the deliberate absence
+        # of "scrollInverter" beside it: see the header's conflicts section, it
+        # would double-invert against this repo's own global setting.
+        "smoothScroll"
+
+        # Capture and OCR, both on the free control-option-command layer
+        # (screenshot on 4, text-from-screen on T), so macOS keeps its own
+        # command-shift-3/4/5 and screencapture.location in ./common.nix stands.
+        "screenshot"
+        "screenOCR"
+
+        # command-X then command-V moves a file in Finder, instead of the
+        # command-option-V that nothing outside macOS uses.
+        "finderCutPaste"
+
+        # Closing the last window quits the app, for the handful (Obsidian,
+        # Notes, browsers) that otherwise linger with no window at all.
+        "autoQuit"
+
+        # System monitor, one id per metric family. OVERLAPS the `stats` cask in
+        # ./homebrew-base.nix — see the header's conflicts section before
+        # deciding which of the two keeps the menu bar.
+        "monitorCPU"
+        "monitorGPU"
+        "monitorMemory"
+        "monitorNetwork"
+        "monitorDisk"
+        "monitorPower"
+
+        # One-click system actions: light/dark, keyboard backlight, empty the
+        # Trash, eject every disk. Wants the Finder automation grant.
+        "quickToggles"
+
+        # Lock the keyboard and black out the displays to wipe them down.
+        "cleaningMode"
+
+        # Removal and leftovers. `uninstaller` takes an app's caches, prefs and
+        # helpers with it; `cleaner` sweeps what a normal drag-to-Trash left
+        # behind. Both reach further with the optional Full Disk Access grant.
+        "uninstaller"
+        "cleaner"
+
+        # Homebrew formulae and casks without a terminal. Read-mostly here --
+        # ./homebrew-base.nix is authoritative for anything that should survive
+        # a rebuild, and `onActivation.cleanup = "none"` means a cask installed
+        # by hand through this pane simply persists undeclared.
+        "homebrew"
+
+        # Strip tracking parameters from copied links.
+        "urlCleaner"
+
+        # A floating shelf to park files mid-drag and drop them somewhere else
+        # later, instead of holding a drag across a window switch.
+        "shelf"
+      ];
+      description = ''
+        Features to install on a fresh host. Everything omitted is written off,
+        which in Vorssaint means uninstalled: it disappears from Settings, the
+        menu panel and the menu bar, its service never instantiates, and it
+        spends no CPU or energy. Nothing is deleted — a feature switched back on
+        later, here or in the hub, returns with its old settings.
+
+        Only ever applied to a Mac that has not been set up yet; see the header.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    homebrew.casks = ["vorssaint"];
+
+    launchd.user.agents.vorssaint = {
+      script = ''
+        # `set -u` and nothing more: nix-darwin's shell for a launchd script is
+        # not guaranteed to be bash, and there is nothing here to pipefail.
+        set -u
+
+        DOMAIN="${domain}"
+
+        # `hasOnboarded` is the app's own "setup is finished" marker. Absent (a
+        # Mac that has never run it) or false is the only state we write in.
+        if [ "$(/usr/bin/defaults read "$DOMAIN" hasOnboarded 2>/dev/null || echo 0)" = "1" ]; then
+          echo "vorssaint: already set up, leaving the Features hub alone"
+        else
+          echo "vorssaint: seeding the Features hub with ${chosen}"
+
+        ${featureWrites}
+
+          # The in-app launch-at-login toggle registers an SMAppService login
+          # item that nix neither owns nor can assert, and the agent this script
+          # runs from already does the job. Pin it off so the two never both
+          # register. See nixos/CLAUDE.md → "Launching GUI apps at login".
+          /usr/bin/defaults write "$DOMAIN" launchAtLoginWanted -bool false
+
+          # Last, deliberately: it is the marker that stops the next run. An
+          # interrupted seed leaves it unset and simply redoes the whole thing.
+          /usr/bin/defaults write "$DOMAIN" hasOnboarded -bool true
+        fi
+
+        # `open` on a running app just activates it, so this is safe to re-run
+        # on every activation. -g = don't steal focus, -j = launch hidden.
+        exec /usr/bin/open -g -j -a /Applications/Vorssaint.app
+      '';
+
+      serviceConfig = {
+        RunAtLoad = true;
+        # Where "Unable to find application named 'Vorssaint'" shows up if the
+        # cask hasn't installed yet on a fresh host, and where the seed reports
+        # whether it ran.
+        StandardOutPath = "/Users/${user}/Library/Logs/vorssaint.log";
+        StandardErrorPath = "/Users/${user}/Library/Logs/vorssaint.log";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds [Vorssaint](https://github.com/vorssaint/vorssaint-utils) — a PowerToys-shaped menu bar suite — to **moria and citadel**. Dungeon is skipped: it's headless, and nearly every feature here is an interactive one.

> Rewritten from the original description, which described a design this PR no longer has. moria was deployed off an early commit and the deploy found a real bug; the last three commits are the consequence.

## There is no config file

Vorssaint's Features hub is GUI-only, and its "export settings" goes through an `NSSavePanel` — no CLI, no watched file, no import flag. What it *does* have is an ordinary UserDefaults domain: one bool per feature, `featureAvailable.<id>`, where the ids are the `AppFeature` raw values (`Sources/Vorssaint/Core/FeatureCatalog.swift`), plus a `hasOnboarded` marker the app sets when its wizard finishes.

So `nixos/modules/darwin/vorssaint.nix` seeds those keys once, before the app's first launch, and then leaves them alone.

**A seed, not `system.defaults.CustomUserPreferences`.** The hub writes these same keys at runtime, so enforcing them every `just dr` would silently undo anything toggled in the GUI — and availability is only read at launch, so a mid-session rewrite wouldn't take effect until a relaunch anyway.

**In `postActivation`, not the login agent — this is the part moria taught us.** nix-darwin's activation order is user agents → Homebrew → postActivation. An agent-hosted seed therefore always fires on a Mac where the cask doesn't exist yet, and both ways out are bad: seeding blind is wrong on its own terms (the update-tour markers are read out of the app bundle), and waiting-then-retrying leaves a window where the app is installed, unconfigured, and one Spotlight hit away. moria's log shows exactly that — the retry seeded *while the wizard was already open*, and completing the wizard overwrote it. A seed that gets one chance must not spend it racing a human. From `postActivation` the cask is already installed and whoever typed `just dr` is still watching it finish. The root-vs-user objection is solved with nix-darwin's own idiom, `launchctl asuser "$(id -u -- user)" sudo --user=user --`.

Two bugs a review pass caught before that, both of which broke the headline promise:

- **The seed skipped the wizard but landed on the post-*update* path** — a release-notes tour plus a support ask whose window has its close button explicitly hidden, both calling `activate(ignoringOtherApps:)`. Now suppressed the way the app's own `markOnboardingComplete()` does.
- **Availability is a layer *above* each feature's own enable key.** Most of the list ships with that key off, so features arrived installed and inert. 12 enable-key writes now go with the 54 availability writes.

## The feature list

21 features, read back off moria after that host was configured by hand — so citadel comes up matching moria rather than matching a video. It started from [this video](https://youtu.be/s8dzlv4WuNk); it isn't that anymore.

Vorssaint overlaps four things already deployed here, and the list only dodges some of them **on purpose**:

| | |
|---|---|
| Out for good | `superKey` — Karabiner owns the Caps Lock hold; two event taps on one key is broken, not merely redundant. |
| Out, but adoptable | `scrollInverter` — `common.nix` sets `com.apple.swipescrolldirection = false`, which already inverts both devices, so this would invert the mouse twice. Flipping that global back to `true` in the same commit is how to adopt it. |
| In, despite overlapping | The app switcher and Dock previews (AeroSpace), the command bar and clipboard history (Raycast), the `monitor*` readouts (the `stats` cask). |

Two things to know about what's in:

- **`switcher` replaces ⌘Tab.** Its enable key ships *on*, so installing it is enough.
- **`commandBar` is installed with its shortcut left off** — the only feature treated that way. Its default binding is ⌥Space, which is Raycast's hotkey, and taking over the launcher key on two Macs isn't something a seed should do silently. It still opens from the menu panel.

The `monitor*` overlap with `stats` is deliberate and reversible: if Vorssaint's version earns its place (speed test, disk health and battery power draw in one panel), dropping `stats` from `homebrew-base.nix` is the follow-up.

## Deploy impact

- **moria** — unaffected. Its hand-picked hub stays; the `hasOnboarded` gate means the seed won't overwrite it. To move it onto the declared list: `defaults delete com.vorssaint.utils hasOnboarded && just dr moria`.
- **citadel** — gets the declared list on first deploy, seeded during `just dr` before the app can be opened.

TCC can't be declared, so the grants join Ice's and Handy's in `nixos/docs/darwin-post-deploy.md` — Accessibility, Screen Recording, System Audio Recording, Automation → Finder, plus Camera and Microphone.

## Verification

CI is green on `443fab5`, including **Validate Darwin configurations** — the darwin eval that couldn't be run from the Linux session this was written in, and the gate I'd flagged as outstanding through three mechanism changes.

Locally: `alejandra` and `deadnix` clean; the generated seed script rendered by hand-modelling nix's `''` interpolation and checked with `bash -n`; and the three behavioural paths exercised against stubbed `defaults`/`open` — a fresh seed writes 71 keys with `hasOnboarded` last, a re-run writes nothing but still launches, and a write failing mid-seed exits non-zero with `hasOnboarded` unset so the next run redoes it. The feature ids, enable keys and the checklist's permission list were each diffed programmatically against the app's own Swift source rather than transcribed.