### PR TITLE
feat(pi): vendor web-fetch, bash-guard, ask-user-question from pi-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,10 +78,9 @@ nixos/secrets/.env
 claude-commands/mozilla/
 # Skills are found as top-level dirs, so they take a prefix instead of a subdir.
 claude-skills/mozilla-*/
-<<<<<<< Updated upstream
 
-# pi extension dependencies. The sandbox extension needs `npm install` in its
-# own directory (see dot/pi/CLAUDE.md); the tree itself is not ours to carry.
+# pi extension dependencies. Each needs `npm install` in its own directory
+# (see dot/pi/CLAUDE.md); the tree itself is not ours to carry.
 dot/pi/extensions-available/*/node_modules/
-=======
->>>>>>> Stashed changes
+dot/pi/.pi/agent/extensions/web-fetch/node_modules/
+dot/pi/.pi/agent/extensions/bash-guard/node_modules/

--- a/claude-skills/youtube-transcript/SKILL.md
+++ b/claude-skills/youtube-transcript/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: youtube-transcript
+description: Fetch the transcript and title of a YouTube video as JSON. Use when the user provides a YouTube URL and you need the spoken content (captions) for analysis, summarization, quoting, or search.
+---
+
+# YouTube Transcript
+
+<!-- Vendored from https://github.com/amosblomqvist/pi-config/blob/main/skills/youtube-transcript -->
+
+Fetches a YouTube video's title and full transcript by pulling captions via `yt-dlp`. Prefers manual English subtitles, falls back to auto-generated English.
+
+## Requirements
+
+- `yt-dlp` and `ffmpeg` on PATH (already in `nixos/config/base-packages.nix` on every managed host)
+- Python 3
+
+## Usage
+
+Run `fetch_transcript.py` from this skill's own directory (the directory this SKILL.md lives in):
+
+```bash
+python3 fetch_transcript.py "<youtube_url>"
+```
+
+## Output
+
+Prints a JSON object to stdout:
+
+```json
+{
+  "title": "Video title",
+  "transcript": "full transcript text as a single string"
+}
+```
+
+Progress/info logs go to stderr. On failure (no English captions, network error, bad URL), the script exits non-zero with a message on stderr.
+
+## Notes
+
+- Only English captions are attempted (`en`, `en-US`, `en-GB`, then any `en*`). Manual captions are preferred over auto-generated.
+- Transcript is plain text with timing/formatting stripped — not timestamped.
+- For non-English videos or videos with captions disabled, the script will fail.

--- a/claude-skills/youtube-transcript/fetch_transcript.py
+++ b/claude-skills/youtube-transcript/fetch_transcript.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Fetch a YouTube video's title and transcript via yt-dlp.
+
+Prefers manual English captions, falls back to auto-generated. Uses yt-dlp
+itself to download the caption file so we don't have to deal with SSL/cert
+issues from a bare urllib request.
+"""
+import sys
+import os
+import glob
+import shutil
+import subprocess
+import tempfile
+import json
+
+
+def get_metadata(url):
+    cmd = [
+        "yt-dlp",
+        "--dump-json",
+        "--no-warnings",
+        "--skip-download",
+        url,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing yt-dlp: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def pick_english_lang(info):
+    """Return (lang_code, is_auto) for the best English caption track, or None."""
+    subs = info.get("subtitles") or {}
+    auto = info.get("automatic_captions") or {}
+
+    preferred = ["en", "en-US", "en-GB"]
+
+    # 1. Manual, preferred order
+    for lang in preferred:
+        if lang in subs:
+            return lang, False
+    # 2. Any manual en*
+    for lang in subs:
+        if lang.startswith("en"):
+            return lang, False
+    # 3. Auto, preferred order
+    for lang in preferred:
+        if lang in auto:
+            return lang, True
+    # 4. Any auto en*
+    for lang in auto:
+        if lang.startswith("en"):
+            return lang, True
+    return None
+
+
+def download_subtitle(url, lang, is_auto, outdir):
+    """Use yt-dlp to download the json3 subtitle file. Returns the file path."""
+    cmd = [
+        "yt-dlp",
+        "--skip-download",
+        "--no-warnings",
+        "--sub-format", "json3",
+        "--sub-langs", lang,
+        "--write-auto-subs" if is_auto else "--write-subs",
+        "-o", os.path.join(outdir, "%(id)s.%(ext)s"),
+        url,
+    ]
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Error downloading subtitles via yt-dlp: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    matches = glob.glob(os.path.join(outdir, "*.json3"))
+    if not matches:
+        print("yt-dlp did not produce a json3 subtitle file.", file=sys.stderr)
+        sys.exit(1)
+    return matches[0]
+
+
+def extract_text_from_json3(path):
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    text_parts = []
+    for event in data.get("events", []):
+        for seg in event.get("segs", []) or []:
+            text = seg.get("utf8", "")
+            if text.strip() and text != "\n":
+                text_parts.append(text.strip())
+    return " ".join(text_parts)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python fetch_transcript.py <youtube_url>", file=sys.stderr)
+        sys.exit(1)
+
+    url = sys.argv[1]
+
+    print("Fetching video metadata...", file=sys.stderr)
+    info = get_metadata(url)
+    title = info.get("title", "Unknown_Title")
+
+    pick = pick_english_lang(info)
+    if pick is None:
+        print(f"No English subtitles found for video: {title}", file=sys.stderr)
+        sys.exit(1)
+    lang, is_auto = pick
+
+    tmpdir = tempfile.mkdtemp(prefix="yt-transcript-")
+    try:
+        print(
+            f"Downloading {'auto ' if is_auto else ''}captions ({lang})...",
+            file=sys.stderr,
+        )
+        sub_path = download_subtitle(url, lang, is_auto, tmpdir)
+        transcript = extract_text_from_json3(sub_path)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    output = {"title": title, "transcript": transcript}
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/dot/pi/.pi/agent/extensions/ask-user-question.ts
+++ b/dot/pi/.pi/agent/extensions/ask-user-question.ts
@@ -1,0 +1,669 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+	Editor,
+	type EditorTheme,
+	Key,
+	Text,
+	matchesKey,
+	truncateToWidth,
+	wrapTextWithAnsi,
+} from "@mariozechner/pi-tui";
+import { Type } from "@sinclair/typebox";
+
+interface AskOption {
+	label: string;
+	value: string;
+	description?: string;
+}
+
+interface DisplayOption extends AskOption {
+	id: string;
+	index?: number;
+	isOther?: boolean;
+	isSubmit?: boolean;
+}
+
+interface TextAnswer {
+	type: "text";
+	label: string;
+	value: string;
+}
+
+interface OptionAnswer {
+	type: "option";
+	label: string;
+	value: string;
+	index: number;
+}
+
+interface OtherAnswer {
+	type: "other";
+	label: string;
+	value: string;
+}
+
+type AskAnswer = TextAnswer | OptionAnswer | OtherAnswer;
+type AskUserQuestionStatus = "answered" | "cancelled" | "unavailable";
+type AskUserQuestionMode = "text" | "single-select" | "multi-select";
+
+interface AskUserQuestionResultDetails {
+	status: AskUserQuestionStatus;
+	question: string;
+	context?: string;
+	mode: AskUserQuestionMode;
+	answers: AskAnswer[];
+	message?: string;
+}
+
+const OptionSchema = Type.Object({
+	label: Type.String({
+		description:
+			'Display label for the option. If you recommend an option, place it first and append "(Recommended)" to the label.',
+	}),
+	value: Type.Optional(
+		Type.String({
+			description: "Optional machine-readable value returned for the option. Defaults to the label.",
+		}),
+	),
+	description: Type.Optional(Type.String({ description: "Optional extra detail shown below the option." })),
+});
+
+const AskUserQuestionParams = Type.Object({
+	question: Type.String({
+		description: "The single question to ask the user. Ask exactly one question per tool call.",
+	}),
+	details: Type.Optional(
+		Type.String({
+			description: "Optional extra context or instructions shown under the question.",
+		}),
+	),
+	options: Type.Optional(
+		Type.Array(OptionSchema, {
+			description:
+				"Optional multiple-choice options. Omit or pass an empty array for free-form text input. Users will always be able to choose Other and type a custom answer when options are provided.",
+		}),
+	),
+	multiSelect: Type.Optional(
+		Type.Boolean({
+			description: "Set to true to allow multiple answers to be selected for a question.",
+		}),
+	),
+});
+
+function normalizeOptions(options: Array<{ label: string; value?: string; description?: string }> | undefined): AskOption[] {
+	return (options || [])
+		.map((option) => ({
+			label: option.label.trim(),
+			value: option.value?.trim() || option.label.trim(),
+			description: option.description?.trim() || undefined,
+		}))
+		.filter((option) => option.label.length > 0);
+}
+
+function getOtherLabel(options: AskOption[]): string {
+	return options.some((option) => option.label.toLowerCase() === "other") ? "Other (custom)" : "Other";
+}
+
+function createEditorTheme(theme: any): EditorTheme {
+	return {
+		borderColor: (s) => theme.fg("accent", s),
+		selectList: {
+			selectedPrefix: (t) => theme.fg("accent", t),
+			selectedText: (t) => theme.fg("accent", t),
+			description: (t) => theme.fg("muted", t),
+			scrollInfo: (t) => theme.fg("dim", t),
+			noMatch: (t) => theme.fg("warning", t),
+		},
+	};
+}
+
+function addWrapped(lines: string[], text: string, width: number, indent = ""): void {
+	const contentWidth = Math.max(1, width - indent.length);
+	for (const line of wrapTextWithAnsi(text, contentWidth)) {
+		lines.push(truncateToWidth(`${indent}${line}`, width));
+	}
+}
+
+function formatAnswerForModel(answer: AskAnswer): string {
+	switch (answer.type) {
+		case "text":
+			return answer.label;
+		case "other":
+			return `Other: ${answer.label}`;
+		case "option":
+			return `${answer.index}. ${answer.label}`;
+	}
+}
+
+function answerSortRank(answer: AskAnswer): number {
+	switch (answer.type) {
+		case "option":
+			return answer.index;
+		case "other":
+			return Number.MAX_SAFE_INTEGER - 1;
+		case "text":
+			return Number.MAX_SAFE_INTEGER;
+	}
+}
+
+function sortAnswers(answers: AskAnswer[]): AskAnswer[] {
+	return [...answers].sort((a, b) => answerSortRank(a) - answerSortRank(b));
+}
+
+function buildStructuredResult(
+	status: AskUserQuestionStatus,
+	question: string,
+	mode: AskUserQuestionMode,
+	answers: AskAnswer[],
+	context?: string,
+	message?: string,
+) {
+	return {
+		status,
+		question,
+		context,
+		mode,
+		answers,
+		message,
+	} as AskUserQuestionResultDetails;
+}
+
+function cancelledResult(question: string, mode: AskUserQuestionMode, context?: string) {
+	const message = "User cancelled the question";
+	return {
+		content: [{ type: "text" as const, text: message }],
+		details: buildStructuredResult("cancelled", question, mode, [], context, message),
+	};
+}
+
+function unavailableResult(question: string, mode: AskUserQuestionMode, message: string, context?: string) {
+	return {
+		content: [{ type: "text" as const, text: message }],
+		details: buildStructuredResult("unavailable", question, mode, [], context, message),
+	};
+}
+
+function buildResult(question: string, context: string | undefined, mode: AskUserQuestionMode, answers: AskAnswer[]) {
+	let text: string;
+	if (mode === "text") {
+		const answer = answers[0];
+		text = answer.label.trim().length > 0 ? `User answered: ${answer.label}` : "User submitted an empty response";
+	} else if (mode === "single-select") {
+		text = `User selected: ${formatAnswerForModel(answers[0])}`;
+	} else {
+		text = `User selected:\n${answers.map((answer) => `- ${formatAnswerForModel(answer)}`).join("\n")}`;
+	}
+
+	return {
+		content: [{ type: "text" as const, text }],
+		details: buildStructuredResult("answered", question, mode, answers, context),
+	};
+}
+
+async function askSingleChoice(
+	ctx: any,
+	question: string,
+	context: string | undefined,
+	options: AskOption[],
+): Promise<AskAnswer | null> {
+	const otherLabel = getOtherLabel(options);
+	const allOptions: DisplayOption[] = [
+		...options.map((option, index) => ({ ...option, id: `option:${index}`, index: index + 1 })),
+		{ id: "other", label: otherLabel, value: "__other__", isOther: true },
+	];
+
+	return ctx.ui.custom<AskAnswer | null>((tui: any, theme: any, _kb: any, done: (result: AskAnswer | null) => void) => {
+		let optionIndex = 0;
+		let editMode = false;
+		let cachedLines: string[] | undefined;
+		let cachedWidth = -1;
+		const editor = new Editor(tui, createEditorTheme(theme));
+
+		editor.onSubmit = (value) => {
+			const trimmed = value.trim();
+			if (!trimmed) return;
+			done({ type: "other", label: trimmed, value: trimmed });
+		};
+
+		function refresh() {
+			cachedLines = undefined;
+			tui.requestRender();
+		}
+
+		function handleInput(data: string) {
+			if (editMode) {
+				if (matchesKey(data, Key.escape)) {
+					editMode = false;
+					editor.setText("");
+					refresh();
+					return;
+				}
+				editor.handleInput(data);
+				refresh();
+				return;
+			}
+
+			if (matchesKey(data, Key.up)) {
+				optionIndex = Math.max(0, optionIndex - 1);
+				refresh();
+				return;
+			}
+			if (matchesKey(data, Key.down)) {
+				optionIndex = Math.min(allOptions.length - 1, optionIndex + 1);
+				refresh();
+				return;
+			}
+			if (matchesKey(data, Key.enter)) {
+				const selected = allOptions[optionIndex];
+				if (selected.isOther) {
+					editMode = true;
+					editor.setText("");
+					refresh();
+					return;
+				}
+				done({
+					type: "option",
+					label: selected.label,
+					value: selected.value,
+					index: selected.index!,
+				});
+				return;
+			}
+			if (matchesKey(data, Key.escape)) {
+				done(null);
+			}
+		}
+
+		function render(width: number): string[] {
+			// The cache MUST be keyed on width: pi-tui calls requestRender() but NOT
+			// invalidate() on terminal resize, so render() can be re-entered with a
+			// new width. Returning stale wider lines trips the TUI width guard and
+			// crashes the process.
+			if (cachedLines && cachedWidth === width) return cachedLines;
+
+			const lines: string[] = [];
+			const add = (text: string) => lines.push(truncateToWidth(text, width));
+
+			add(theme.fg("accent", "─".repeat(width)));
+			addWrapped(lines, theme.fg("text", ` ${question}`), width);
+			if (context) {
+				lines.push("");
+				addWrapped(lines, theme.fg("muted", ` ${context}`), width);
+			}
+			lines.push("");
+
+			for (let i = 0; i < allOptions.length; i++) {
+				const option = allOptions[i];
+				const selected = i === optionIndex;
+				const prefix = selected ? theme.fg("accent", "> ") : "  ";
+				const label = option.isOther ? option.label : `${option.index}. ${option.label}`;
+				const styled = selected ? theme.fg("accent", label) : theme.fg("text", label);
+				add(`${prefix}${styled}`);
+				if (option.description) {
+					addWrapped(lines, theme.fg("muted", option.description), width, "     ");
+				}
+			}
+
+			if (editMode) {
+				lines.push("");
+				add(theme.fg("muted", " Write your custom answer:"));
+				for (const line of editor.render(Math.max(1, width - 2))) {
+					add(` ${line}`);
+				}
+				lines.push("");
+				add(theme.fg("dim", " Enter to submit • Esc to go back"));
+			} else {
+				lines.push("");
+				add(theme.fg("dim", " ↑↓ navigate • Enter select • Esc cancel"));
+			}
+
+			add(theme.fg("accent", "─".repeat(width)));
+			cachedLines = lines;
+			cachedWidth = width;
+			return lines;
+		}
+
+		return {
+			render,
+			invalidate: () => {
+				cachedLines = undefined;
+			},
+			handleInput,
+		};
+	});
+}
+
+async function askMultiChoice(
+	ctx: any,
+	question: string,
+	context: string | undefined,
+	options: AskOption[],
+): Promise<AskAnswer[] | null> {
+	const otherLabel = getOtherLabel(options);
+	const choiceItems: DisplayOption[] = options.map((option, index) => ({
+		...option,
+		id: `option:${index}`,
+		index: index + 1,
+	}));
+	const submitItem: DisplayOption = { id: "submit", label: "Submit", value: "__submit__", isSubmit: true };
+	const allItems: DisplayOption[] = [
+		...choiceItems,
+		{ id: "other", label: otherLabel, value: "__other__", isOther: true },
+		submitItem,
+	];
+
+	return ctx.ui.custom<AskAnswer[] | null>((tui: any, theme: any, _kb: any, done: (result: AskAnswer[] | null) => void) => {
+		let optionIndex = 0;
+		let editMode = false;
+		let cachedLines: string[] | undefined;
+		let cachedWidth = -1;
+		const selected = new Map<string, AskAnswer>();
+		const editor = new Editor(tui, createEditorTheme(theme));
+
+		editor.onSubmit = (value) => {
+			const trimmed = value.trim();
+			if (!trimmed) return;
+			selected.set("other", { type: "other", label: trimmed, value: trimmed });
+			editMode = false;
+			refresh();
+		};
+
+		function refresh() {
+			cachedLines = undefined;
+			tui.requestRender();
+		}
+
+		function toggleOption(item: DisplayOption) {
+			if (selected.has(item.id)) {
+				selected.delete(item.id);
+			} else {
+				selected.set(item.id, {
+					type: "option",
+					label: item.label,
+					value: item.value,
+					index: item.index!,
+				});
+			}
+			refresh();
+		}
+
+		function handleInput(data: string) {
+			if (editMode) {
+				if (matchesKey(data, Key.escape)) {
+					editMode = false;
+					editor.setText(selected.get("other")?.label || "");
+					refresh();
+					return;
+				}
+				editor.handleInput(data);
+				refresh();
+				return;
+			}
+
+			if (matchesKey(data, Key.up)) {
+				optionIndex = Math.max(0, optionIndex - 1);
+				refresh();
+				return;
+			}
+			if (matchesKey(data, Key.down)) {
+				optionIndex = Math.min(allItems.length - 1, optionIndex + 1);
+				refresh();
+				return;
+			}
+
+			const current = allItems[optionIndex];
+			if (matchesKey(data, Key.space)) {
+				if (current.isSubmit) return;
+				if (current.isOther) {
+					if (selected.has("other")) {
+						selected.delete("other");
+						refresh();
+					} else {
+						editMode = true;
+						editor.setText("");
+						refresh();
+					}
+					return;
+				}
+				toggleOption(current);
+				return;
+			}
+
+			if (matchesKey(data, Key.enter)) {
+				if (current.isSubmit) {
+					if (selected.size > 0) {
+						done(sortAnswers(Array.from(selected.values())));
+					}
+					return;
+				}
+				if (current.isOther) {
+					editMode = true;
+					editor.setText(selected.get("other")?.label || "");
+					refresh();
+					return;
+				}
+				toggleOption(current);
+				return;
+			}
+
+			if (matchesKey(data, Key.escape)) {
+				done(null);
+			}
+		}
+
+		function render(width: number): string[] {
+			// The cache MUST be keyed on width: pi-tui calls requestRender() but NOT
+			// invalidate() on terminal resize, so render() can be re-entered with a
+			// new width. Returning stale wider lines trips the TUI width guard and
+			// crashes the process.
+			if (cachedLines && cachedWidth === width) return cachedLines;
+
+			const lines: string[] = [];
+			const add = (text: string) => lines.push(truncateToWidth(text, width));
+
+			add(theme.fg("accent", "─".repeat(width)));
+			addWrapped(lines, theme.fg("text", ` ${question}`), width);
+			if (context) {
+				lines.push("");
+				addWrapped(lines, theme.fg("muted", ` ${context}`), width);
+			}
+			lines.push("");
+
+			for (let i = 0; i < allItems.length; i++) {
+				const item = allItems[i];
+				const isFocused = i === optionIndex;
+				const prefix = isFocused ? theme.fg("accent", "> ") : "  ";
+
+				if (item.isSubmit) {
+					const label = selected.size > 0 ? `✓ ${item.label} (${selected.size} selected)` : `○ ${item.label}`;
+					const styled = isFocused
+						? theme.fg("accent", label)
+						: theme.fg(selected.size > 0 ? "success" : "dim", label);
+					add(`${prefix}${styled}`);
+					continue;
+				}
+
+				if (item.isOther) {
+					const other = selected.get("other");
+					const marker = other ? "[x]" : "[ ]";
+					const suffix = other ? ` — ${other.label}` : "";
+					const styled = isFocused
+						? theme.fg("accent", `${marker} ${item.label}${suffix}`)
+						: theme.fg(other ? "success" : "text", `${marker} ${item.label}${suffix}`);
+					add(`${prefix}${styled}`);
+					continue;
+				}
+
+				const checked = selected.has(item.id);
+				const marker = checked ? "[x]" : "[ ]";
+				const label = `${marker} ${item.index}. ${item.label}`;
+				const styled = isFocused
+					? theme.fg("accent", label)
+					: theme.fg(checked ? "success" : "text", label);
+				add(`${prefix}${styled}`);
+				if (item.description) {
+					addWrapped(lines, theme.fg("muted", item.description), width, "     ");
+				}
+			}
+
+			if (editMode) {
+				lines.push("");
+				add(theme.fg("muted", " Write your custom answer:"));
+				for (const line of editor.render(Math.max(1, width - 2))) {
+					add(` ${line}`);
+				}
+				lines.push("");
+				add(theme.fg("dim", " Enter to save • Esc to go back"));
+			} else {
+				lines.push("");
+				if (selected.size === 0) {
+					add(theme.fg("warning", " Select at least one answer before submitting."));
+				}
+				add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter edit/submit • Esc cancel"));
+			}
+
+			add(theme.fg("accent", "─".repeat(width)));
+			cachedLines = lines;
+			cachedWidth = width;
+			return lines;
+		}
+
+		return {
+			render,
+			invalidate: () => {
+				cachedLines = undefined;
+			},
+			handleInput,
+		};
+	});
+}
+
+// Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at
+// a time, so ALL pop-up-style tools (ask_user_question, quiz, ...) must
+// serialize against each other, not just against themselves. We stash one
+// mutex on globalThis so separate extension files can share it without
+// importing each other.
+const SHARED_UI_LOCK_KEY = "__piSharedUiLock";
+function getSharedUiLock() {
+	const g = globalThis as any;
+	if (!g[SHARED_UI_LOCK_KEY]) {
+		let chain: Promise<void> = Promise.resolve();
+		g[SHARED_UI_LOCK_KEY] = {
+			withLock<T>(fn: () => T | Promise<T>): Promise<T> {
+				const prev = chain;
+				let release: () => void;
+				chain = new Promise<void>((r) => { release = r; });
+				return prev.then(fn).finally(() => release!());
+			},
+		};
+	}
+	return g[SHARED_UI_LOCK_KEY] as { withLock<T>(fn: () => T | Promise<T>): Promise<T> };
+}
+const sharedUiLock = getSharedUiLock();
+
+function withUILock<T>(fn: () => Promise<T>): Promise<T> {
+	return sharedUiLock.withLock(fn);
+}
+
+export default function askUserQuestion(pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "ask_user_question",
+		label: "ask_user_question",
+		description:
+			"Ask the user a single question and pause execution until they answer. Use this when requirements are ambiguous, user preferences are needed, a decision would materially affect implementation, or you need confirmation before proceeding. Ask exactly one question per tool call, and prefer multiple separate tool calls over bundling unrelated questions together.",
+		promptSnippet:
+			"Use this tool to ask exactly one clarifying question, missing-requirement question, preference question, or decision question before continuing.",
+		promptGuidelines: [
+			"Ask exactly one question per tool call.",
+			"If you need answers to multiple questions, make multiple separate ask_user_question tool calls instead of combining them into one prompt.",
+			'Users will always be able to select "Other" to provide custom text input when options are provided.',
+			"Use multiSelect: true only when you need multiple answers to the same question.",
+			'If you recommend a specific option, make it the first option in the list and add "(Recommended)" at the end of the label.',
+			"Prefer this tool over guessing when requirements, preferences, or implementation choices are unclear.",
+			"Use this tool when multiple valid implementation paths exist and the preferred path depends on user choice.",
+		],
+		parameters: AskUserQuestionParams,
+
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			const options = normalizeOptions(params.options);
+			const context = params.details?.trim() || undefined;
+			const mode: AskUserQuestionMode = options.length === 0 ? "text" : params.multiSelect ? "multi-select" : "single-select";
+
+			if (signal?.aborted) {
+				return cancelledResult(params.question, mode, context);
+			}
+
+			if (!ctx.hasUI) {
+				return unavailableResult(params.question, mode, "ask_user_question requires interactive mode UI", context);
+			}
+
+			return withUILock(async () => {
+				if (mode === "text") {
+					const editorTitle = context ? `${params.question}\n\n${context}` : params.question;
+					const answer = await ctx.ui.editor(editorTitle);
+					if (answer === undefined) {
+						return cancelledResult(params.question, mode, context);
+					}
+					return buildResult(params.question, context, mode, [
+						{ type: "text", label: answer.trim(), value: answer.trim() },
+					]);
+				}
+
+				if (mode === "single-select") {
+					const answer = await askSingleChoice(ctx, params.question, context, options);
+					if (!answer) {
+						return cancelledResult(params.question, mode, context);
+					}
+					return buildResult(params.question, context, mode, [answer]);
+				}
+
+				const answers = await askMultiChoice(ctx, params.question, context, options);
+				if (!answers) {
+					return cancelledResult(params.question, mode, context);
+				}
+				return buildResult(params.question, context, mode, answers);
+			});
+		},
+
+		renderCall(args, theme) {
+			const options = normalizeOptions(args.options as Array<{ label: string; value?: string; description?: string }> | undefined);
+			let text = theme.fg("toolTitle", theme.bold("ask_user_question ")) + theme.fg("muted", args.question);
+			if (args.multiSelect) {
+				text += theme.fg("dim", " [multi-select]");
+			}
+			if (options.length > 0) {
+				const labels = [...options.map((option) => option.label), getOtherLabel(options)].join(", ");
+				text += `\n${theme.fg("dim", `  Options: ${labels}`)}`;
+			}
+			return new Text(text, 0, 0);
+		},
+
+		renderResult(result, _options, theme) {
+			const details = result.details as AskUserQuestionResultDetails | undefined;
+			if (!details) {
+				const first = result.content[0];
+				return new Text(first?.type === "text" ? first.text : "", 0, 0);
+			}
+
+			if (details.status === "cancelled") {
+				return new Text(theme.fg("warning", details.message || "Cancelled"), 0, 0);
+			}
+
+			if (details.status === "unavailable") {
+				return new Text(theme.fg("warning", details.message || "ask_user_question unavailable"), 0, 0);
+			}
+
+			const lines = details.answers.map((answer) => {
+				switch (answer.type) {
+					case "text":
+						return `${theme.fg("success", "✓ ")}${theme.fg("accent", answer.label || "(empty response)")}`;
+					case "other":
+						return `${theme.fg("success", "✓ ")}${theme.fg("muted", "Other: ")}${theme.fg("accent", answer.label)}`;
+					case "option":
+						return `${theme.fg("success", "✓ ")}${theme.fg("accent", `${answer.index}. ${answer.label}`)}`;
+				}
+			});
+			return new Text(lines.join("\n"), 0, 0);
+		},
+	});
+}

--- a/dot/pi/.pi/agent/extensions/bash-guard/README.md
+++ b/dot/pi/.pi/agent/extensions/bash-guard/README.md
@@ -1,0 +1,65 @@
+# bash-guard (pi extension)
+
+Intercepts agent-issued `bash` tool calls and applies different protection depending on whether
+the session is interactive (main session) or non-interactive (spawned subagent).
+
+## Modes
+
+Behaviour is determined at registration time via the `PI_SUBAGENT_DEPTH` environment variable,
+which pi-subagents injects into every spawned process.
+
+### Main session (`PI_SUBAGENT_DEPTH` = 0 or unset) — interactive prompt
+
+- Heuristically detects destructive/questionable commands via shell-aware parsing
+- Prompts for **any** `git ...` command (escalates severity for especially risky ones: `git rm`,
+  `git reset --hard`, `git clean -fdx`, `git push --force`, `git reflog expire`, `git gc --prune`)
+- Prompts for disk/volume tooling: `diskutil`, `hdiutil`, `mkfs*`, `newfs_*`, `wipefs`, `parted`,
+  `fdisk`, `gdisk/sgdisk`, `cryptsetup`, `pvcreate/vgcreate/lvcreate`, `zpool`, `lsblk`
+- Prompts for: `rm`/`rmdir`/`unlink`, `sudo`, `find -delete`, `dd`, `truncate`, `sed -i`,
+  `perl -pi`, `chmod/chown -R`, `mv/cp --force`, `kill`/`pkill`/`killall`, `shutdown`/`reboot`,
+  `systemctl stop/disable`, `curl|sh`/`wget|sh`, `kubectl delete`, `terraform destroy`,
+  `aws s3 rm --recursive`, `gcloud delete`, shell redirections (`>`, `>>`, `2>`), pipes
+- Shows a 2-option dialog: **Run** / **Abort**
+- If aborted, the tool call is blocked and the model receives a clear reason
+- Remembers recently aborted commands for 60 s to prevent retry loops
+
+### Subagent (`PI_SUBAGENT_DEPTH` ≥ 1) — headless hard-block
+
+Spawned subagents have no UI (stdin is `/dev/null`), so prompting is impossible. Instead,
+a focused set of catastrophic/unrecoverable operations is hard-blocked with no user interaction:
+
+| Pattern | Reason |
+|---|---|
+| `rm -r` / `-rf` / `-Rf` | Recursive deletion |
+| `sudo` | Elevated privileges |
+| `curl\|sh`, `wget\|sh` | Pipe to shell (remote code execution) |
+| `mkfs*`, `newfs_*` | Filesystem formatting |
+| `wipefs` | Disk signature wipe |
+| `diskutil erase/zeroDisk/secureErase/reformat` | Destructive disk operation |
+| `dd of=/dev/…` | Raw disk write |
+| `parted`, `fdisk`, `gdisk`, `sgdisk` | Partition table management |
+| `cryptsetup` | Disk encryption management |
+| `zpool` | ZFS pool management |
+| `shutdown`, `reboot`, `halt`, `poweroff` | System power operation |
+| `terraform destroy` | Infrastructure teardown |
+| `kubectl delete` | Kubernetes resource deletion |
+| `aws s3 rm --recursive` | Bulk S3 deletion |
+| `git commit` | Main-session operation |
+| `git pull` | Main-session operation |
+| `git push` | Main-session operation |
+| `git reset --hard` | Discard all uncommitted changes |
+| `git clean -f` | Delete untracked files |
+| `git reflog expire` | Remove recovery history |
+| `git gc --prune` | Prune unreachable objects |
+
+All other commands (including routine git operations) pass through unaffected.
+
+## Install
+
+Auto-discovered from `~/.pi/agent/extensions/bash-guard/`. Run `/reload` in pi.
+
+## Notes
+
+- Scope: `bash` tool calls only (`write`/`edit` and user `!` commands are not intercepted).
+- `--bash-guard-auto-allow`: main-session flag that allows flagged commands when there is no UI
+  (e.g. running pi non-interactively). Has no effect in subagent sessions.

--- a/dot/pi/.pi/agent/extensions/bash-guard/index.ts
+++ b/dot/pi/.pi/agent/extensions/bash-guard/index.ts
@@ -1,0 +1,550 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder, isToolCallEventType } from "@mariozechner/pi-coding-agent";
+import type { SelectItem } from "@mariozechner/pi-tui";
+import { Container, SelectList, Text } from "@mariozechner/pi-tui";
+import { parse as shellParse } from "shell-quote";
+
+type Severity = "high" | "medium";
+
+type Risk = {
+	severity: Severity;
+	reasons: string[];
+};
+
+type OpToken = { op: string; [k: string]: unknown };
+
+type Token = string | OpToken;
+
+function isOpToken(t: Token): t is OpToken {
+	return typeof t === "object" && t !== null && "op" in t;
+}
+
+function tokensToStrings(tokens: Token[]): string[] {
+	return tokens.filter((t) => typeof t === "string") as string[];
+}
+
+function splitOnOps(tokens: Token[], splitOps: string[]): Token[][] {
+	const out: Token[][] = [];
+	let current: Token[] = [];
+	for (const t of tokens) {
+		if (isOpToken(t) && splitOps.includes(t.op)) {
+			if (current.length) out.push(current);
+			current = [];
+			continue;
+		}
+		current.push(t);
+	}
+	if (current.length) out.push(current);
+	return out;
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+	return args.includes(flag) || args.some((a) => a.startsWith(flag) && flag.length === 2 && a.startsWith("-"));
+}
+
+function anyArgStartsWith(args: string[], prefix: string): boolean {
+	return args.some((a) => a.startsWith(prefix));
+}
+
+function analyzeSegment(seg: Token[]): Risk | null {
+	const reasons: string[] = [];
+	let severity: Severity = "medium";
+
+	const ops = seg.filter(isOpToken).map((o) => o.op);
+	const args = tokensToStrings(seg);
+	if (args.length === 0) return null;
+
+	const cmd = args[0];
+	const rest = args.slice(1);
+
+	// Shell redirection / pipes are handled on the whole command, but keep some segment checks too.
+	if (ops.includes("|") && (args.includes("sh") || args.includes("bash") || args.includes("zsh") || args.includes("fish"))) {
+		reasons.push("pipe to a shell (possible remote code execution)");
+		severity = "high";
+	}
+
+	// sudo
+	if (cmd === "sudo") {
+		reasons.push("sudo (elevated privileges)");
+		severity = "high";
+	}
+
+	// rm/rmdir/unlink
+	if (cmd === "rm" || cmd === "rmdir" || cmd === "unlink") {
+		severity = "high";
+		reasons.push(`${cmd} (file deletion)`);
+		if (rest.some((a) => a.includes("-r") || a.includes("-R"))) reasons.push("recursive delete (-r/-R)");
+		if (rest.some((a) => a.includes("-f"))) reasons.push("forced delete (-f)");
+		if (ops.includes("glob")) reasons.push("glob pattern expansion (may delete many files)");
+	}
+
+	// find -delete
+	if (cmd === "find" && rest.includes("-delete")) {
+		severity = "high";
+		reasons.push("find -delete (bulk deletion)");
+	}
+
+	// git operations (prompt on ANY git command)
+	if (cmd === "git") {
+		const sub = rest[0];
+		const subArgs = rest.slice(1);
+
+		// Always prompt for git commands (user requested). Keep severity medium unless an explicit high-risk pattern is detected.
+		reasons.push(sub ? `git ${sub} (git command)` : "git (git command)");
+
+		if (sub === "rm") {
+			severity = "high";
+			reasons.push("git rm (deletes files from working tree and stages deletions)");
+		}
+		if (sub === "clean" && (subArgs.some((a) => a.includes("-f")) || subArgs.includes("-d") || subArgs.includes("-x"))) {
+			severity = "high";
+			reasons.push("git clean (can delete untracked files)");
+		}
+		if (sub === "reset" && subArgs.includes("--hard")) {
+			severity = "high";
+			reasons.push("git reset --hard (discard changes)");
+		}
+		if ((sub === "checkout" || sub === "restore") && (subArgs.includes(".") || subArgs.includes("--") || subArgs.includes("--source"))) {
+			severity = severity === "high" ? "high" : "medium";
+			reasons.push("git checkout/restore (can overwrite working tree)");
+		}
+		if (sub === "push" && (subArgs.includes("--force") || subArgs.includes("--force-with-lease") || subArgs.includes("-f"))) {
+			severity = "high";
+			reasons.push("git push --force (rewrite remote history)");
+		}
+		if (sub === "reflog" && subArgs.includes("expire")) {
+			severity = "high";
+			reasons.push("git reflog expire (can remove recovery history)");
+		}
+		if (sub === "gc" && subArgs.some((a) => a.startsWith("--prune"))) {
+			severity = "high";
+			reasons.push("git gc --prune (can permanently delete objects)");
+		}
+	}
+
+	// truncate
+	if (cmd === "truncate") {
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push("truncate (in-place size change, can erase contents)");
+	}
+
+	// dd of=
+	if (cmd === "dd" && (anyArgStartsWith(rest, "of=") || rest.includes("of"))) {
+		severity = "high";
+		reasons.push("dd with output file/device (can overwrite data)");
+	}
+
+	// Disk / volume management (prompt aggressively; high risk)
+	// Linux: mkfs.*, wipefs, parted, fdisk, gdisk/sgdisk, lsblk, cryptsetup, LVM tools, zpool
+	// macOS: diskutil, hdiutil, gpt, newfs_*, asr
+	if (cmd.startsWith("mkfs")) {
+		severity = "high";
+		reasons.push("mkfs (filesystem formatting)");
+	}
+	if (cmd.startsWith("newfs_")) {
+		severity = "high";
+		reasons.push("newfs_* (filesystem formatting)");
+	}
+	if (cmd === "wipefs") {
+		severity = "high";
+		reasons.push("wipefs (disk signature wipe)");
+	}
+	if (cmd === "diskutil") {
+		severity = "high";
+		reasons.push("diskutil (disk management command)");
+		if (rest.includes("eraseDisk") || rest.includes("eraseVolume")) {
+			reasons.push("diskutil erase (destructive disk operation)");
+		}
+	}
+	if (cmd === "hdiutil") {
+		severity = "high";
+		reasons.push("hdiutil (disk image management command)");
+	}
+	if (cmd === "gpt") {
+		severity = "high";
+		reasons.push("gpt (partition table manipulation)");
+	}
+	if (cmd === "asr") {
+		severity = "high";
+		reasons.push("asr (Apple Software Restore; can overwrite volumes)");
+	}
+	if (cmd === "parted" || cmd === "fdisk" || cmd === "gdisk" || cmd === "sgdisk") {
+		severity = "high";
+		reasons.push(`${cmd} (disk/partition management)`);
+	}
+	if (cmd === "lsblk") {
+		// Usually read-only, but still disk-related; prompt as requested.
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push("lsblk (disk listing)");
+	}
+	if (cmd === "cryptsetup") {
+		severity = "high";
+		reasons.push("cryptsetup (disk encryption management)");
+	}
+	if (cmd === "pvcreate" || cmd === "vgcreate" || cmd === "lvcreate") {
+		severity = "high";
+		reasons.push(`${cmd} (LVM volume management)`);
+	}
+	if (cmd === "zpool") {
+		severity = "high";
+		reasons.push("zpool (ZFS pool management)");
+	}
+
+	// chmod/chown recursive
+	if (cmd === "chmod" && (rest.includes("-R") || rest.includes("--recursive"))) {
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push("chmod -R (recursive permission changes)");
+	}
+	if (cmd === "chown" && (rest.includes("-R") || rest.includes("--recursive"))) {
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push("chown -R (recursive ownership changes)");
+	}
+
+	// mv/cp overwriting
+	if (cmd === "mv" && (rest.includes("-f") || rest.includes("--force"))) {
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push("mv --force/-f (can overwrite files)");
+	}
+	if (cmd === "cp" && (rest.includes("-f") || rest.includes("--force"))) {
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push("cp --force/-f (can overwrite files)");
+	}
+
+	// sed/perl in-place
+	if (cmd === "sed" && (hasFlag(rest, "-i") || rest.includes("--in-place"))) {
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push("sed -i (in-place file modification)");
+	}
+	if (cmd === "perl" && (rest.includes("-pi") || (rest.includes("-p") && rest.includes("-i")))) {
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push("perl -pi/-i (in-place file modification)");
+	}
+
+	// kill/shutdown/systemctl
+	if (cmd === "kill" || cmd === "pkill" || cmd === "killall") {
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push(`${cmd} (process termination)`);
+		if (rest.includes("-9")) {
+			severity = "high";
+			reasons.push("SIGKILL (-9)");
+		}
+	}
+	if (cmd === "shutdown" || cmd === "reboot") {
+		severity = "high";
+		reasons.push(`${cmd} (system power operation)`);
+	}
+	if (cmd === "systemctl" && (rest.includes("stop") || rest.includes("disable"))) {
+		severity = severity === "high" ? "high" : "medium";
+		reasons.push("systemctl stop/disable (service disruption)");
+	}
+
+	// Remote execution patterns
+	if ((cmd === "curl" || cmd === "wget") && ops.includes("|")) {
+		severity = "high";
+		reasons.push("curl/wget piped (possible remote code execution)");
+	}
+
+	// Infra deletes
+	if (cmd === "kubectl" && rest[0] === "delete") {
+		severity = "high";
+		reasons.push("kubectl delete (resource deletion)");
+	}
+	if (cmd === "terraform" && rest[0] === "destroy") {
+		severity = "high";
+		reasons.push("terraform destroy (infrastructure teardown)");
+	}
+	if (cmd === "aws" && rest[0] === "s3" && rest[1] === "rm" && rest.includes("--recursive")) {
+		severity = "high";
+		reasons.push("aws s3 rm --recursive (bulk deletion)");
+	}
+	if (cmd === "gcloud" && rest.includes("delete")) {
+		severity = "high";
+		reasons.push("gcloud delete (resource deletion)");
+	}
+
+	if (reasons.length === 0) return null;
+	return { severity, reasons };
+}
+
+function analyzeBashCommand(command: string): Risk | null {
+	let tokens: Token[];
+	try {
+		tokens = shellParse(command) as Token[];
+	} catch {
+		// Fallback: if we can't parse, treat it as questionable
+		return { severity: "medium", reasons: ["unparsed shell command (unable to analyze safely)"] };
+	}
+
+	const reasons: string[] = [];
+	let severity: Severity = "medium";
+
+	// Whole-command operator checks
+	const ops = tokens.filter(isOpToken).map((t) => t.op);
+	if (ops.some((op) => op === ">" || op === ">>" || op === "2>" || op === "2>>")) {
+		reasons.push("shell output redirection (can overwrite files)");
+		severity = severity === "high" ? "high" : "medium";
+	}
+	if (ops.includes("<")) {
+		reasons.push("shell input redirection (questionable)");
+	}
+	if (ops.includes("|")) {
+		reasons.push("pipe operator (chained commands)");
+	}
+
+	// Segment analysis (split on &&, ||, ;)
+	const segments = splitOnOps(tokens, ["&&", "||", ";"]);
+	for (const seg of segments) {
+		const segRisk = analyzeSegment(seg);
+		if (!segRisk) continue;
+		if (segRisk.severity === "high") severity = "high";
+		for (const r of segRisk.reasons) reasons.push(r);
+	}
+
+	// De-duplicate reasons
+	const uniq = [...new Set(reasons)];
+	if (uniq.length === 0) return null;
+	return { severity, reasons: uniq };
+}
+
+async function promptRunOrAbort(ctx: any, command: string, risk: Risk): Promise<"run" | "abort"> {
+	if (!ctx.hasUI) return "abort";
+
+	const reasonsText = risk.reasons.map((r) => `• ${r}`).join("\n");
+	const header = `Command flagged as ${risk.severity.toUpperCase()} risk:`;
+	const body = `${header}\n\n${reasonsText}\n\nCommand:\n${command}`;
+
+	const items: SelectItem[] = [
+		{ value: "run", label: "Run", description: "Execute the command" },
+		{ value: "abort", label: "Abort", description: "Block this command" },
+	];
+
+	const choice = await ctx.ui.custom<"run" | "abort">((tui, theme, _kb, done) => {
+		const container = new Container();
+		container.addChild(new DynamicBorder((s: string) => theme.fg("warning", s)));
+		container.addChild(new Text(theme.fg("warning", theme.bold("Potentially destructive bash command")), 1, 0));
+		container.addChild(new Text(body, 1, 0));
+
+		const list = new SelectList(items, items.length, {
+			selectedPrefix: (t) => theme.fg("accent", t),
+			selectedText: (t) => theme.fg("accent", t),
+			description: (t) => theme.fg("muted", t),
+			scrollInfo: (t) => theme.fg("dim", t),
+			noMatch: (t) => theme.fg("warning", t),
+		});
+
+		list.onSelect = (item) => done(item.value as "run" | "abort");
+		list.onCancel = () => done("abort");
+		container.addChild(list);
+
+		container.addChild(new DynamicBorder((s: string) => theme.fg("warning", s)));
+
+		return {
+			render: (w) => container.render(w),
+			invalidate: () => container.invalidate(),
+			handleInput: (data) => {
+				list.handleInput(data);
+				tui.requestRender();
+			},
+		};
+	}, { overlay: true });
+
+	return choice ?? "abort";
+}
+
+// PI_SUBAGENT_DEPTH is 0 (or unset) in the main session and >= 1 in spawned subagent processes.
+// Behaviour branches on this: interactive prompting in the main session, headless hard-block
+// for catastrophic operations in subagents (where stdin is /dev/null and no UI is available).
+const _subagentDepth = Number(process.env.PI_SUBAGENT_DEPTH ?? "0");
+const _isSubagent = Number.isFinite(_subagentDepth) && _subagentDepth >= 1;
+
+// Hard-block patterns for subagent (headless) mode. Criteria: unrecoverable by default AND
+// unlikely to be intentional in an automated context. Fewer false positives over broad coverage —
+// the interactive prompt handles the rest for main sessions.
+const HEADLESS_BLOCKED: Array<{ pattern: RegExp; reason: string }> = [
+	// Recursive deletion
+	{ pattern: /(?<!\bgit\s+)\brm\b[^#\n]*\s-(?:[a-zA-Z]*[rR]|-\brecursive\b)/, reason: "recursive delete (rm -r / -rf / -Rf)" },
+	// Privilege escalation
+	{ pattern: /\bsudo\b/, reason: "elevated privileges (sudo)" },
+	// Remote code execution via pipe-to-shell
+	{ pattern: /\b(curl|wget)\b[^#\n]*\|\s*(ba?sh|zsh|fish|dash|sh)\b/, reason: "pipe to shell (remote code execution)" },
+	// Disk / filesystem destruction
+	{ pattern: /\bmkfs/, reason: "filesystem formatting (mkfs)" },
+	{ pattern: /\bnewfs_\w+/, reason: "filesystem formatting (newfs_*)" },
+	{ pattern: /\bwipefs\b/, reason: "disk signature wipe" },
+	{ pattern: /\bdiskutil\s+(erase|zeroDisk|secureErase|reformat)/i, reason: "destructive disk operation (diskutil)" },
+	{ pattern: /\bdd\b[^#\n]*\bof=\/dev\//, reason: "raw disk write (dd of=/dev/...)" },
+	{ pattern: /\b(parted|fdisk|gdisk|sgdisk)\b/, reason: "partition table management" },
+	{ pattern: /\bcryptsetup\b/, reason: "disk encryption management" },
+	{ pattern: /\bzpool\b/, reason: "ZFS pool management" },
+	// System power
+	{ pattern: /\b(shutdown|reboot|halt|poweroff)\b/, reason: "system power operation" },
+	// Infrastructure teardown
+	{ pattern: /\bterraform\s+destroy\b/, reason: "infrastructure teardown (terraform destroy)" },
+	{ pattern: /\bkubectl\s+delete\b/, reason: "Kubernetes resource deletion" },
+	{ pattern: /\baws\s+s3\s+rm\b[^#\n]*--recursive/, reason: "bulk S3 deletion (aws s3 rm --recursive)" },
+	// Destructive git operations
+	{ pattern: /\bgit\s+commit\b/, reason: "git commit (commits are main-session operations)" },
+	{ pattern: /\bgit\s+pull\b/, reason: "git pull (pulls are main-session operations)" },
+	{ pattern: /\bgit\s+push\b/, reason: "git push (pushes are main-session operations)" },
+	{ pattern: /\bgit\s+reset\b[^#\n]*--hard\b/, reason: "discard all uncommitted changes (git reset --hard)" },
+	{ pattern: /\bgit\s+clean\b[^#\n]*-[a-zA-Z]*f/, reason: "delete untracked files (git clean -f)" },
+	{ pattern: /\bgit\s+reflog\s+expire\b/, reason: "expire reflog (removes recovery history)" },
+	{ pattern: /\bgit\s+gc\b[^#\n]*--prune\b/, reason: "prune unreachable objects (git gc --prune)" },
+];
+
+// Subset of HEADLESS_BLOCKED used as the hard-block floor when bash-guard is
+// disabled in an interactive (main) session. The user explicitly opts into
+// autonomy here, so routine git operations (commit/pull/push) are allowed
+// through; only truly catastrophic / non-recoverable patterns remain blocked.
+const MAIN_DISABLED_BLOCKED: Array<{ pattern: RegExp; reason: string }> = HEADLESS_BLOCKED.filter(
+	({ pattern }) => {
+		const src = pattern.source;
+		return !(
+			src.includes("git\\s+commit") ||
+			src.includes("git\\s+pull") ||
+			// Keep `git push --force` blocked but allow plain `git push`.
+			src === "\\bgit\\s+push\\b"
+		);
+	},
+);
+
+// Warning shown via ctx.ui.setStatus when bash-guard is disabled. Pi joins all
+// extension statuses on a single line sorted alphabetically by key, so:
+//
+// - Key has a leading space so it sorts before any letter-keyed extension,
+//   guaranteeing the warning stays visible (truncateToWidth chops the right).
+// - We deliberately do NOT pad the text to full width — that would push other
+//   extensions' statuses off-screen via truncation.
+// - Background is truecolor pure red (#FF0000) instead of the basic palette
+//   color 41 (which terminals remap per theme, often appearing brown/orange).
+//   Foreground is truecolor white for high contrast on pure red.
+// - NBSPs (U+00A0) handle intra-warning spacing because the footer's
+//   sanitizeStatusText collapses runs of ASCII spaces via / +/g.
+const BASH_GUARD_STATUS_KEY = " bash-guard";
+
+export default function (pi: ExtensionAPI) {
+	if (_isSubagent) {
+		// Subagent mode: hard-block catastrophic operations, no prompting.
+		pi.on("tool_call", async (event) => {
+			if (!isToolCallEventType("bash", event)) return;
+			const command = event.input.command;
+			for (const { pattern, reason } of HEADLESS_BLOCKED) {
+				if (pattern.test(command)) {
+					return {
+						block: true,
+						reason:
+							`Blocked by bash-guard: ${reason}. ` +
+							"This is a non-interactive subagent session — catastrophic operations are not permitted. " +
+							"Propose a safer alternative or ask the parent agent to confirm with the user.",
+					};
+				}
+			}
+		});
+		return;
+	}
+
+	// Main session mode: interactive prompting.
+	pi.registerFlag("bash-guard-auto-allow", {
+		description: "If set, bash-guard will not block when no UI is available (non-interactive modes).",
+		type: "boolean",
+		default: false,
+	});
+
+	pi.registerFlag("bash-guard-disabled", {
+		description: "Start the session with bash-guard disabled (autonomous mode; hard-block floor still applies).",
+		type: "boolean",
+		default: false,
+	});
+
+	// Session-local toggle. Intentionally not persisted across reloads or restarts.
+	let disabled = false;
+
+	pi.on("session_start", async (event, ctx) => {
+		if (event.reason === "startup" && pi.getFlag("--bash-guard-disabled") === true) {
+			disabled = true;
+			const { theme } = ctx.ui;
+			const badge = theme.bg(
+				"toolErrorBg",
+				theme.bold(theme.fg("error", " ⚠ BG OFF ")),
+			);
+			ctx.ui.setStatus(BASH_GUARD_STATUS_KEY, badge);
+		}
+	});
+
+	pi.registerCommand("bash-guard", {
+		description: "Toggle bash-guard between interactive (default) and disabled (autonomous) for this session.",
+		handler: async (_args, ctx) => {
+			disabled = !disabled;
+			if (disabled) {
+				const { theme } = ctx.ui;
+				const badge = theme.bg(
+					"toolErrorBg",
+					theme.bold(theme.fg("error", " ⚠ BG OFF ")),
+				);
+				ctx.ui.setStatus(BASH_GUARD_STATUS_KEY, badge);
+				ctx.ui.notify(
+					"bash-guard DISABLED for this session. Catastrophic operations are still hard-blocked. Run /bash-guard again to re-enable.",
+					"warning",
+				);
+			} else {
+				ctx.ui.setStatus(BASH_GUARD_STATUS_KEY, undefined);
+				ctx.ui.notify("bash-guard re-enabled.", "info");
+			}
+		},
+	});
+
+	// Avoid annoying retry loops: if the exact command was aborted recently, auto-block it.
+	const recentlyAborted = new Map<string, number>();
+	const ABORT_REMEMBER_MS = 60_000;
+
+	pi.on("tool_call", async (event, ctx) => {
+		if (!isToolCallEventType("bash", event)) return;
+
+		const command = event.input.command;
+
+		// Disabled (autonomous) mode: skip interactive prompting entirely, but keep
+		// a hard-block floor for catastrophic operations.
+		if (disabled) {
+			for (const { pattern, reason } of MAIN_DISABLED_BLOCKED) {
+				if (pattern.test(command)) {
+					return {
+						block: true,
+						reason:
+							`Blocked by bash-guard (disabled-mode floor): ${reason}. ` +
+							"Even with bash-guard disabled, this pattern is considered too destructive to run unattended. " +
+							"Re-enable bash-guard with /bash-guard and confirm interactively, or propose a safer alternative.",
+					};
+				}
+			}
+			return;
+		}
+
+		const risk = analyzeBashCommand(command);
+		if (!risk) return;
+
+		const now = Date.now();
+		const lastAbort = recentlyAborted.get(command);
+		if (lastAbort && now - lastAbort < ABORT_REMEMBER_MS) {
+			return {
+				block: true,
+				reason:
+					"Blocked by bash-guard: command was already aborted recently. Ask the user for a safer alternative; do not retry the same command.",
+			};
+		}
+
+		if (!ctx.hasUI && pi.getFlag("--bash-guard-auto-allow")) {
+			// Non-interactive mode: allow when explicitly requested.
+			return;
+		}
+
+		const choice = await promptRunOrAbort(ctx, command, risk);
+		if (choice === "run") return;
+
+		recentlyAborted.set(command, now);
+		return {
+			block: true,
+			reason:
+				"Blocked by user via bash-guard (potentially destructive command). Ask the user for confirmation or propose a non-destructive alternative.",
+		};
+	});
+}

--- a/dot/pi/.pi/agent/extensions/bash-guard/package-lock.json
+++ b/dot/pi/.pi/agent/extensions/bash-guard/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "pi-bash-guard",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pi-bash-guard",
+      "dependencies": {
+        "shell-quote": "^1.8.3"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/dot/pi/.pi/agent/extensions/bash-guard/package.json
+++ b/dot/pi/.pi/agent/extensions/bash-guard/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pi-bash-guard",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "shell-quote": "^1.8.3"
+  },
+  "pi": {
+    "extensions": ["./index.ts"]
+  }
+}

--- a/dot/pi/.pi/agent/extensions/web-fetch/index.ts
+++ b/dot/pi/.pi/agent/extensions/web-fetch/index.ts
@@ -1,0 +1,650 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+import { Text } from "@mariozechner/pi-tui";
+import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
+import TurndownService from "turndown";
+
+const USER_AGENT =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+const DEFAULT_TIMEOUT_MS = 30000;
+const MAX_RESPONSE_SIZE = 5 * 1024 * 1024;
+const MAX_PDF_SIZE = 20 * 1024 * 1024;
+const MIN_USEFUL_CONTENT = 500;
+const JINA_READER_BASE = "https://r.jina.ai/";
+const JINA_TIMEOUT_MS = 30000;
+
+const turndown = new TurndownService({
+	headingStyle: "atx",
+	codeBlockStyle: "fenced",
+});
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface FetchResult {
+	url: string;
+	title: string;
+	content: string;
+	error: string | null;
+}
+
+// ── PDF Extraction ───────────────────────────────────────────────────
+
+function isPDF(url: string, contentType?: string): boolean {
+	if (contentType?.includes("application/pdf")) return true;
+	try {
+		return new URL(url).pathname.toLowerCase().endsWith(".pdf");
+	} catch {
+		return false;
+	}
+}
+
+async function extractPDF(
+	buffer: ArrayBuffer,
+	url: string,
+): Promise<FetchResult> {
+	const { getDocumentProxy } = await import("unpdf");
+	const pdf = await getDocumentProxy(new Uint8Array(buffer));
+
+	const metadata = await pdf.getMetadata();
+	const metadataInfo =
+		metadata.info && typeof metadata.info === "object"
+			? (metadata.info as Record<string, unknown>)
+			: null;
+
+	const metaTitle =
+		typeof metadataInfo?.Title === "string"
+			? metadataInfo.Title.trim()
+			: "";
+	const metaAuthor =
+		typeof metadataInfo?.Author === "string"
+			? metadataInfo.Author.trim()
+			: "";
+
+	let urlTitle = "document";
+	try {
+		const { basename } = await import("node:path");
+		urlTitle =
+			basename(new URL(url).pathname, ".pdf")
+				.replace(/[_-]+/g, " ")
+				.trim() || "document";
+	} catch {
+		/* ignore */
+	}
+	const title = metaTitle || urlTitle;
+
+	const maxPages = Math.min(pdf.numPages, 100);
+	const pages: string[] = [];
+	for (let i = 1; i <= maxPages; i++) {
+		const page = await pdf.getPage(i);
+		const textContent = await page.getTextContent();
+		const pageText = textContent.items
+			.map((item: unknown) => (item as { str?: string }).str || "")
+			.join(" ")
+			.replace(/\s+/g, " ")
+			.trim();
+		if (pageText) pages.push(pageText);
+	}
+
+	const lines: string[] = [
+		`# ${title}`,
+		"",
+		`> Source: ${url}`,
+		`> Pages: ${pdf.numPages}${pdf.numPages > maxPages ? ` (extracted first ${maxPages})` : ""}`,
+	];
+	if (metaAuthor) lines.push(`> Author: ${metaAuthor}`);
+	lines.push("", "---", "");
+	lines.push(pages.join("\n\n"));
+
+	if (pdf.numPages > maxPages) {
+		lines.push(
+			"",
+			"---",
+			"",
+			`*[Truncated: Only first ${maxPages} of ${pdf.numPages} pages extracted]*`,
+		);
+	}
+
+	return { url, title, content: lines.join("\n"), error: null };
+}
+
+// ── RSC Content Extraction (Next.js) ─────────────────────────────────
+
+function extractRSCContent(
+	html: string,
+): { title: string; content: string } | null {
+	if (!html.includes("self.__next_f.push")) return null;
+
+	const chunkMap = new Map<string, string>();
+	const scriptRegex =
+		/<script>self\.__next_f\.push\(\[1,"([\s\S]*?)"\]\)<\/script>/g;
+
+	for (const match of html.matchAll(scriptRegex)) {
+		let content: string;
+		try {
+			content = JSON.parse('"' + match[1] + '"');
+		} catch {
+			continue;
+		}
+		for (const line of content.split("\n")) {
+			if (!line.trim()) continue;
+			const colonIdx = line.indexOf(":");
+			if (colonIdx <= 0 || colonIdx > 4) continue;
+			const id = line.slice(0, colonIdx);
+			if (!/^[0-9a-f]+$/i.test(id)) continue;
+			const payload = line.slice(colonIdx + 1);
+			if (!payload) continue;
+			const existing = chunkMap.get(id);
+			if (!existing || payload.length > existing.length) {
+				chunkMap.set(id, payload);
+			}
+		}
+	}
+
+	if (chunkMap.size === 0) return null;
+
+	const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/);
+	const title = titleMatch?.[1]?.split("|")[0]?.trim() || "";
+
+	const parsedCache = new Map<string, unknown>();
+	function getParsedChunk(id: string): unknown | null {
+		if (parsedCache.has(id)) return parsedCache.get(id);
+		const chunk = chunkMap.get(id);
+		if (!chunk || !chunk.startsWith("[")) {
+			parsedCache.set(id, null);
+			return null;
+		}
+		try {
+			const parsed = JSON.parse(chunk);
+			parsedCache.set(id, parsed);
+			return parsed;
+		} catch {
+			parsedCache.set(id, null);
+			return null;
+		}
+	}
+
+	type Node = unknown;
+	const visitedRefs = new Set<string>();
+
+	function extractNode(node: Node, ctx = { inCode: false }): string {
+		if (node === null || node === undefined) return "";
+		if (typeof node === "string") {
+			const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
+			if (refMatch) {
+				const refId = refMatch[1];
+				if (visitedRefs.has(refId)) return "";
+				visitedRefs.add(refId);
+				const refNode = getParsedChunk(refId);
+				const result = refNode ? extractNode(refNode, ctx) : "";
+				visitedRefs.delete(refId);
+				return result;
+			}
+			if (
+				!ctx.inCode &&
+				(node === "$undefined" ||
+					node === "$" ||
+					/^\$[A-Z]/.test(node))
+			)
+				return "";
+			return node.trim() ? node : "";
+		}
+		if (typeof node === "number") return String(node);
+		if (typeof node === "boolean") return "";
+		if (!Array.isArray(node)) return "";
+
+		if (node[0] === "$" && typeof node[1] === "string") {
+			const tag = node[1] as string;
+			const props = (node[3] || {}) as Record<string, unknown>;
+			const skipTags = [
+				"script", "style", "svg", "path", "circle", "link", "meta",
+				"template", "button", "input", "nav", "footer", "aside",
+			];
+			if (skipTags.includes(tag)) return "";
+
+			if (tag.startsWith("$L")) {
+				const refId = tag.slice(2);
+				if (visitedRefs.has(refId)) return "";
+				if (props.baseId && props.children)
+					return `## ${String(props.children)}\n\n`;
+				visitedRefs.add(refId);
+				const refNode = getParsedChunk(refId);
+				let result = "";
+				if (refNode) result = extractNode(refNode, ctx);
+				else if (props.children)
+					result = extractNode(props.children as Node, ctx);
+				visitedRefs.delete(refId);
+				return result;
+			}
+
+			const children = props.children;
+			const content = children
+				? extractNode(children as Node, ctx)
+				: "";
+
+			switch (tag) {
+				case "h1": return `# ${content.trim()}\n\n`;
+				case "h2": return `## ${content.trim()}\n\n`;
+				case "h3": return `### ${content.trim()}\n\n`;
+				case "h4": return `#### ${content.trim()}\n\n`;
+				case "h5": return `##### ${content.trim()}\n\n`;
+				case "h6": return `###### ${content.trim()}\n\n`;
+				case "p": return `${content.trim()}\n\n`;
+				case "code": {
+					const cc = children
+						? extractNode(children as Node, { inCode: true })
+						: "";
+					return ctx.inCode ? cc : `\`${cc}\``;
+				}
+				case "pre": {
+					const pc = children
+						? extractNode(children as Node, { inCode: true })
+						: "";
+					return "```\n" + pc + "\n```\n\n";
+				}
+				case "strong": case "b": return `**${content}**`;
+				case "em": case "i": return `*${content}*`;
+				case "li": return `- ${content.trim()}\n`;
+				case "ul": case "ol": return content + "\n";
+				case "blockquote": return `> ${content.trim()}\n\n`;
+				case "a": {
+					const href = props.href as string | undefined;
+					return href && !href.startsWith("#")
+						? `[${content}](${href})`
+						: content;
+				}
+				default: return content;
+			}
+		}
+
+		return (node as Node[]).map((n) => extractNode(n, ctx)).join("");
+	}
+
+	const mainChunk = getParsedChunk("23");
+	if (mainChunk) {
+		const content = extractNode(mainChunk);
+		if (content.trim().length > 100) {
+			return {
+				title,
+				content: content.replace(/\n{3,}/g, "\n\n").trim(),
+			};
+		}
+	}
+
+	const contentParts: { order: number; text: string }[] = [];
+	for (const [id] of chunkMap) {
+		if (id === "23") continue;
+		const parsed = getParsedChunk(id);
+		if (!parsed) continue;
+		visitedRefs.clear();
+		const text = extractNode(parsed);
+		if (
+			text.trim().length > 50 &&
+			!text.includes("page was not found") &&
+			!text.includes("404")
+		) {
+			contentParts.push({
+				order: parseInt(id, 16),
+				text: text.trim(),
+			});
+		}
+	}
+
+	if (contentParts.length === 0) return null;
+	contentParts.sort((a, b) => a.order - b.order);
+
+	const seen = new Set<string>();
+	const uniqueParts: string[] = [];
+	for (const part of contentParts) {
+		const key = part.text.slice(0, 150);
+		if (!seen.has(key)) {
+			seen.add(key);
+			uniqueParts.push(part.text);
+		}
+	}
+
+	const content = uniqueParts
+		.join("\n\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+	return content.length > 100 ? { title, content } : null;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function isLikelyJSRendered(html: string): boolean {
+	const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+	if (!bodyMatch) return false;
+	const textContent = bodyMatch[1]
+		.replace(/<script[\s\S]*?<\/script>/gi, "")
+		.replace(/<style[\s\S]*?<\/style>/gi, "")
+		.replace(/<[^>]+>/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	const scriptCount = (html.match(/<script/gi) || []).length;
+	return textContent.length < 500 && scriptCount > 3;
+}
+
+function extractHeadingTitle(text: string): string | null {
+	const match = text.match(/^#{1,2}\s+(.+)/m);
+	if (!match) return null;
+	const cleaned = match[1].replace(/\*+/g, "").trim();
+	return cleaned || null;
+}
+
+// ── Jina Reader Fallback ─────────────────────────────────────────────
+
+async function extractWithJinaReader(
+	url: string,
+	signal?: AbortSignal,
+): Promise<FetchResult | null> {
+	try {
+		const res = await fetch(JINA_READER_BASE + url, {
+			headers: { Accept: "text/markdown", "X-No-Cache": "true" },
+			signal: AbortSignal.any([
+				AbortSignal.timeout(JINA_TIMEOUT_MS),
+				...(signal ? [signal] : []),
+			]),
+		});
+		if (!res.ok) return null;
+
+		const content = await res.text();
+		const contentStart = content.indexOf("Markdown Content:");
+		if (contentStart < 0) return null;
+
+		const markdownPart = content.slice(contentStart + 17).trim();
+		if (
+			markdownPart.length < 100 ||
+			markdownPart.startsWith("Loading...") ||
+			markdownPart.startsWith("Please enable JavaScript")
+		) {
+			return null;
+		}
+
+		const title =
+			extractHeadingTitle(markdownPart) ??
+			new URL(url).pathname.split("/").pop() ??
+			url;
+		return { url, title, content: markdownPart, error: null };
+	} catch {
+		return null;
+	}
+}
+
+// ── Main HTTP Extraction ─────────────────────────────────────────────
+
+async function extractViaHttp(
+	url: string,
+	signal?: AbortSignal,
+): Promise<FetchResult> {
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+	const onAbort = () => controller.abort();
+	signal?.addEventListener("abort", onAbort);
+
+	try {
+		const response = await fetch(url, {
+			signal: controller.signal,
+			headers: {
+				"User-Agent": USER_AGENT,
+				Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+				"Accept-Language": "en-US,en;q=0.9",
+				"Cache-Control": "no-cache",
+				"Sec-Fetch-Dest": "document",
+				"Sec-Fetch-Mode": "navigate",
+				"Sec-Fetch-Site": "none",
+				"Sec-Fetch-User": "?1",
+				"Upgrade-Insecure-Requests": "1",
+			},
+		});
+
+		if (!response.ok) {
+			return {
+				url, title: "", content: "",
+				error: `HTTP ${response.status}: ${response.statusText}`,
+			};
+		}
+
+		const contentType = response.headers.get("content-type") || "";
+		const contentLengthHeader = response.headers.get("content-length");
+		const isPDFContent = isPDF(url, contentType);
+		const maxSize = isPDFContent ? MAX_PDF_SIZE : MAX_RESPONSE_SIZE;
+
+		if (contentLengthHeader) {
+			const contentLength = parseInt(contentLengthHeader, 10);
+			if (contentLength > maxSize) {
+				return {
+					url, title: "", content: "",
+					error: `Response too large (${Math.round(contentLength / 1024 / 1024)}MB)`,
+				};
+			}
+		}
+
+		if (isPDFContent) {
+			const buffer = await response.arrayBuffer();
+			return await extractPDF(buffer, url);
+		}
+
+		if (
+			contentType.includes("application/octet-stream") ||
+			contentType.includes("image/") ||
+			contentType.includes("audio/") ||
+			contentType.includes("video/") ||
+			contentType.includes("application/zip")
+		) {
+			return {
+				url, title: "", content: "",
+				error: `Unsupported content type: ${contentType.split(";")[0]}`,
+			};
+		}
+
+		const text = await response.text();
+		const isHTML =
+			contentType.includes("text/html") ||
+			contentType.includes("application/xhtml+xml");
+
+		if (!isHTML) {
+			const title =
+				extractHeadingTitle(text) ??
+				new URL(url).pathname.split("/").pop() ??
+				url;
+			return { url, title, content: text, error: null };
+		}
+
+		const { document } = parseHTML(text);
+		const reader = new Readability(document as unknown as Document);
+		const article = reader.parse();
+
+		if (!article) {
+			const rscResult = extractRSCContent(text);
+			if (rscResult) {
+				return {
+					url,
+					title: rscResult.title,
+					content: rscResult.content,
+					error: null,
+				};
+			}
+
+			const jsRendered = isLikelyJSRendered(text);
+			return {
+				url, title: "", content: "",
+				error: jsRendered
+					? "Page appears to be JavaScript-rendered (content loads dynamically)"
+					: "Could not extract readable content from HTML structure",
+			};
+		}
+
+		const markdown = turndown.turndown(article.content);
+
+		if (markdown.length < MIN_USEFUL_CONTENT) {
+			return {
+				url,
+				title: article.title || "",
+				content: markdown,
+				error: isLikelyJSRendered(text)
+					? "Page appears to be JavaScript-rendered (content loads dynamically)"
+					: "Extracted content appears incomplete",
+			};
+		}
+
+		return {
+			url,
+			title: article.title || "",
+			content: markdown,
+			error: null,
+		};
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { url, title: "", content: "", error: message };
+	} finally {
+		clearTimeout(timeoutId);
+		signal?.removeEventListener("abort", onAbort);
+	}
+}
+
+// ── Public Fetch Function ────────────────────────────────────────────
+
+async function fetchAndExtract(
+	url: string,
+	signal?: AbortSignal,
+): Promise<FetchResult> {
+	if (signal?.aborted) {
+		return { url, title: "", content: "", error: "Aborted" };
+	}
+
+	try {
+		new URL(url);
+	} catch {
+		return { url, title: "", content: "", error: "Invalid URL" };
+	}
+
+	const httpResult = await extractViaHttp(url, signal);
+	if (signal?.aborted)
+		return { url, title: "", content: "", error: "Aborted" };
+	if (!httpResult.error) return httpResult;
+
+	if (
+		httpResult.error.startsWith("Unsupported content type") ||
+		httpResult.error.startsWith("Response too large")
+	) {
+		return httpResult;
+	}
+
+	const jinaResult = await extractWithJinaReader(url, signal);
+	if (jinaResult) return jinaResult;
+	if (signal?.aborted)
+		return { url, title: "", content: "", error: "Aborted" };
+
+	return {
+		...httpResult,
+		error: `${httpResult.error}\n\nThe page may be JavaScript-rendered. Try:\n  • A different URL for the same content\n  • web_search to find cached/alternative versions`,
+	};
+}
+
+// ── Extension Registration ───────────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "web_fetch",
+		label: "Web Fetch",
+		description:
+			"Fetch a web page and extract readable content as clean markdown. Uses Readability + Turndown for high-quality HTML→markdown conversion. Handles PDFs, plain text, and falls back to Jina Reader for JS-rendered pages.",
+		promptSnippet:
+			"Fetch a URL and extract readable content as markdown. Supports HTML pages, PDFs, and plain text.",
+
+		parameters: Type.Object({
+			url: Type.String({ description: "URL to fetch" }),
+		}),
+
+		async execute(_toolCallId, params, signal) {
+			const result = await fetchAndExtract(params.url, signal);
+
+			if (result.error) {
+				throw new Error(`${params.url}: ${result.error}`);
+			}
+
+			const header = result.title
+				? `# ${result.title}\n\nSource: ${result.url}\n\n---\n\n`
+				: "";
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: header + result.content,
+					},
+				],
+				details: {
+					url: result.url,
+					title: result.title,
+					chars: result.content.length,
+				},
+			};
+		},
+
+		renderCall(args, theme, context) {
+			const text =
+				(context.lastComponent as Text | undefined) ??
+				new Text("", 0, 0);
+			const { url } = args as { url?: string };
+			if (!url) {
+				text.setText(
+					theme.fg("toolTitle", theme.bold("fetch ")) +
+						theme.fg("error", "(no URL)"),
+				);
+				return text;
+			}
+			const display =
+				url.length > 70 ? url.slice(0, 67) + "..." : url;
+			text.setText(
+				theme.fg("toolTitle", theme.bold("fetch ")) +
+					theme.fg("accent", display),
+			);
+			return text;
+		},
+
+		renderResult(result, { expanded, isPartial }, theme, context) {
+			const text =
+				(context.lastComponent as Text | undefined) ??
+				new Text("", 0, 0);
+
+			if (isPartial) {
+				text.setText(theme.fg("warning", "Fetching…"));
+				return text;
+			}
+
+			if (context.isError) {
+				const msg =
+					result.content.find((c) => c.type === "text")?.text ||
+					"Error";
+				text.setText(theme.fg("error", msg));
+				return text;
+			}
+
+			const details = result.details as {
+				title?: string;
+				chars?: number;
+			};
+
+			const title = details?.title || "Untitled";
+			const chars = details?.chars ?? 0;
+			const status =
+				theme.fg("success", title) +
+				theme.fg("muted", ` (${chars} chars)`);
+
+			if (!expanded) {
+				text.setText(status);
+				return text;
+			}
+
+			const content =
+				result.content.find((c) => c.type === "text")?.text || "";
+			const preview =
+				content.length > 500
+					? content.slice(0, 500) + "..."
+					: content;
+			text.setText(status + "\n" + theme.fg("dim", preview));
+			return text;
+		},
+	});
+}

--- a/dot/pi/.pi/agent/extensions/web-fetch/package-lock.json
+++ b/dot/pi/.pi/agent/extensions/web-fetch/package-lock.json
@@ -1,0 +1,221 @@
+{
+	"name": "pi-web-fetch",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "pi-web-fetch",
+			"dependencies": {
+				"@mozilla/readability": "^0.5.0",
+				"linkedom": "^0.16.0",
+				"turndown": "^7.2.0",
+				"unpdf": "^1.4.0"
+			}
+		},
+		"node_modules/@mixmark-io/domino": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/@mozilla/readability": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
+			"integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"license": "ISC"
+		},
+		"node_modules/css-select": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cssom": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+			"license": "MIT"
+		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+			"integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+			"license": "MIT"
+		},
+		"node_modules/htmlparser2": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+			"integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.1.0",
+				"entities": "^4.5.0"
+			}
+		},
+		"node_modules/linkedom": {
+			"version": "0.16.11",
+			"resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.11.tgz",
+			"integrity": "sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==",
+			"license": "ISC",
+			"dependencies": {
+				"css-select": "^5.1.0",
+				"cssom": "^0.5.0",
+				"html-escaper": "^3.0.3",
+				"htmlparser2": "^9.1.0",
+				"uhyphen": "^0.2.0"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
+		"node_modules/turndown": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+			"integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@mixmark-io/domino": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=18",
+				"npm": ">=9"
+			}
+		},
+		"node_modules/uhyphen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+			"integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+			"license": "ISC"
+		},
+		"node_modules/unpdf": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.4.0.tgz",
+			"integrity": "sha512-TahIk0xdH/4jh/MxfclzU79g40OyxtP00VnEUZdEkJoYtXAHWLiir6t3FC6z3vDqQTzc2ZHcla6uEiVTNjejuA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@napi-rs/canvas": "^0.1.69"
+			},
+			"peerDependenciesMeta": {
+				"@napi-rs/canvas": {
+					"optional": true
+				}
+			}
+		}
+	}
+}

--- a/dot/pi/.pi/agent/extensions/web-fetch/package.json
+++ b/dot/pi/.pi/agent/extensions/web-fetch/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "pi-web-fetch",
+	"private": true,
+	"type": "module",
+	"pi": {
+		"extensions": ["./index.ts"]
+	},
+	"dependencies": {
+		"@mozilla/readability": "^0.5.0",
+		"linkedom": "^0.16.0",
+		"turndown": "^7.2.0",
+		"unpdf": "^1.4.0"
+	}
+}

--- a/dot/pi/CLAUDE.md
+++ b/dot/pi/CLAUDE.md
@@ -780,6 +780,55 @@ harness's concrete tool in a small table — see `claude-skills/teach/SKILL.md` 
 the pattern (adapted from [amosblomqvist/learn](https://github.com/amosblomqvist/learn),
 a `pi`-only config this repo does not otherwise vendor).
 
+## Extensions vendored from pi-config
+
+Four pieces of [amosblomqvist/pi-config](https://github.com/amosblomqvist/pi-config)
+(a general-purpose pi setup, separate from the `learn` config above) fill gaps
+nothing else here covers. Everything else in that repo was skipped — its
+`web-search/` needs a paid Google Custom Search key (we deliberately moved to
+free self-hosted SearXNG instead), its `analyze-sessions/` skill risks
+reintroducing the stale-cost-catalog bug `pi-usage.py` was written to work
+around, and the rest (`browser/`, `custom-header.ts`, `prompt-snippets/`,
+everything under `deprecated/`) had no matching need here.
+
+- **`extensions/web-fetch/`** — URL → clean markdown (Mozilla Readability +
+  Turndown), with PDF extraction via `unpdf`. pi has no built-in fetch tool
+  (Claude Code has `WebFetch`; pi had nothing). Falls back to `r.jina.ai` (a
+  third-party reader service) for pages Readability can't parse — worth
+  knowing before a URL goes through it. Vendored with its own
+  `package.json`/`package-lock.json`; `pi.nix`'s `installPiExtensionDeps`
+  activation runs `npm install` in it, same pattern as
+  `extensions-available/sandbox`.
+- **`extensions/bash-guard/`** — a real gap, not overlap. `pi-permission-system`
+  only gates file writes; `orchestration-guardrails.ts` only arms itself for
+  `/orchestrate-pi` runs (`PI_GUARDRAILS=1` or a `guardrails.json`). Neither
+  protects an ordinary interactive session from `rm -rf`, `sudo`, `git push
+  --force`, disk-formatting tools, etc. — bash-guard prompts Run/Abort for
+  those in the main session, and hard-blocks a narrower catastrophic set with
+  no UI when it detects it's running inside a subagent
+  (`PI_SUBAGENT_DEPTH >= 1`, set by `pi-agent-suite`'s subagent runner). See
+  its own `extensions/bash-guard/README.md` for the full command list. Also
+  npm-installed by `installPiExtensionDeps` (one dependency, `shell-quote`).
+- **`extensions/ask-user-question.ts`** — a UI popup for open questions with no
+  right answer. Single file, no npm deps (uses pi's own bundled
+  `@mariozechner/pi-tui`, like `web-search.ts` already does), so nothing extra
+  to install. This is exactly the extension `claude-skills/teach/SKILL.md`'s
+  tool-mapping table already anticipates ("if an ask_user_question-style
+  popup extension is installed, use it — not required") — with it installed,
+  pi's `teach` sessions get the same popup UX as Claude Code's
+  `AskUserQuestion`, not just a plain-text fallback.
+- **`claude-skills/youtube-transcript/`** — not pi-only: a real skill, vendored
+  into the shared `claude-skills/` directory (see "Skills" above) so both
+  agents get it from one copy. Fetches a video's title and transcript via
+  `yt-dlp`, which is already in `nixos/config/base-packages.nix` on every
+  managed host — no new system dependency.
+
+**Measured token cost, this host, `~/Git/toolbox` cwd (same method as "The
+token budget" below):** 13,232 tokens/request without these three extensions,
+14,004 with — **+772 tokens/request** for all three together. All three loaded
+with no errors in a live smoke test (`pi --mode json -p 'Reply with exactly:
+OK'`, checked stderr for extension-load failures).
+
 ## Web search
 
 `extensions/web-search.ts` registers a `web_search` tool against our self-hosted

--- a/dot/pi/CLAUDE.md
+++ b/dot/pi/CLAUDE.md
@@ -825,9 +825,23 @@ everything under `deprecated/`) had no matching need here.
 
 **Measured token cost, this host, `~/Git/toolbox` cwd (same method as "The
 token budget" below):** 13,232 tokens/request without these three extensions,
-14,004 with — **+772 tokens/request** for all three together. All three loaded
-with no errors in a live smoke test (`pi --mode json -p 'Reply with exactly:
-OK'`, checked stderr for extension-load failures).
+14,004 with — **+772 tokens/request** for all three together.
+
+**Functionally verified live, not just load-checked.** A bare `-p 'Reply with
+exactly: OK'` smoke test proves registration didn't throw at import — it
+never actually calls a tool, so it can't prove much beyond that. Actually
+invoking each:
+- `web_fetch` — asked to fetch a real URL; it ran and returned a result. This
+  also settles a real question raised in review: `web-fetch/index.ts` imports
+  plain `typebox` the way `web-search.ts`'s comment above says isn't
+  resolvable from `~/.pi/agent/extensions`. It resolves anyway — pi's loader
+  reaches into its own bundled TypeBox for extensions the same way it does
+  for `@mariozechner/pi-tui`, so that comment is stale (or was true of an
+  older pi version); nothing to fix in `web-fetch`.
+- `bash-guard` — in the same session, the model tried `curl ... | grep`
+  as a fallback and bash-guard correctly blocked it (pipe detection).
+- `ask-user-question` — not yet exercised live; it's a UI popup, so it needs
+  an interactive session rather than `-p`.
 
 ## Web search
 

--- a/nixos/modules/programs/tui/pi.nix
+++ b/nixos/modules/programs/tui/pi.nix
@@ -340,7 +340,10 @@ in {
         for ext in web-fetch bash-guard; do
           ext_dir="${config.home.homeDirectory}/.pi/agent/extensions/$ext"
           if [ -d "$ext_dir" ] && [ ! -d "$ext_dir/node_modules" ]; then
-            (cd "$ext_dir" && npm install --no-audit --no-fund 2>/dev/null) || echo "WARNING: npm install failed for pi extension $ext"
+            # Deliberately not silencing stderr here (unlike installPiPackages
+            # above): a first-time install failing is the interesting case,
+            # and swallowing it left no way to tell why.
+            (cd "$ext_dir" && npm install --no-audit --no-fund) || echo "WARNING: npm install failed for pi extension $ext"
           fi
         done
         echo "✓ Pi extension deps installed"

--- a/nixos/modules/programs/tui/pi.nix
+++ b/nixos/modules/programs/tui/pi.nix
@@ -324,5 +324,27 @@ in {
         echo "✓ Pi packages installed"
       fi
     '';
+
+    # web-fetch and bash-guard are vendored local extensions (not `pi install`
+    # packages — nothing in cfg.packages names them) with their own
+    # package.json. The folded stow symlink at ~/.pi/agent/extensions already
+    # makes their source visible; only node_modules is missing on a fresh
+    # checkout, since it's gitignored (see dot/pi/CLAUDE.md). Guarded on the
+    # directory existing so this no-ops harmlessly if it runs before
+    # stowDotfiles on a fresh host — the next activation picks it up once stow
+    # has.
+    home.activation.installPiExtensionDeps = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      export PATH="/opt/homebrew/bin:/run/current-system/sw/bin:$HOME/.nix-profile/bin:$PATH"
+
+      if command -v npm &>/dev/null; then
+        for ext in web-fetch bash-guard; do
+          ext_dir="${config.home.homeDirectory}/.pi/agent/extensions/$ext"
+          if [ -d "$ext_dir" ] && [ ! -d "$ext_dir/node_modules" ]; then
+            (cd "$ext_dir" && npm install --no-audit --no-fund 2>/dev/null) || echo "WARNING: npm install failed for pi extension $ext"
+          fi
+        done
+        echo "✓ Pi extension deps installed"
+      fi
+    '';
   };
 }


### PR DESCRIPTION
## Summary

Vendors four pieces of [amosblomqvist/pi-config](https://github.com/amosblomqvist/pi-config) that fill real gaps in the current pi setup, and fixes an unrelated bug found along the way.

- **`extensions/web-fetch/`** — URL → clean markdown (Readability + Turndown) with PDF extraction. pi had no fetch tool (Claude Code has `WebFetch`; pi had nothing). No API key. Falls back to `r.jina.ai` for pages it can't parse.
- **`extensions/bash-guard/`** — prompts Run/Abort on dangerous interactive-session bash commands (`rm -rf`, `sudo`, `git push --force`, disk tools...), hard-blocks a narrower catastrophic set with no UI inside subagents. Neither `pi-permission-system` (write-only) nor `orchestration-guardrails.ts` (only arms for `/orchestrate-pi`) cover ordinary interactive sessions today.
- **`extensions/ask-user-question.ts`** — open-question popup UI. Exactly what `claude-skills/teach/SKILL.md`'s tool-mapping table already anticipated as optional.
- **`claude-skills/youtube-transcript/`** — vendored as a *shared* skill (not pi-only), so both Claude Code and pi get it from one copy via the cross-harness `skills` setting added in the last PR.

Skipped from the source repo, with reasons: `web-search/` needs a paid Google key (we run free self-hosted SearXNG); `analyze-sessions/` risks reintroducing the stale DeepSeek-cost-catalog bug `pi-usage.py` already works around; `browser/`, `custom-header.ts`, `prompt-snippets/`, and everything under `deprecated/` matched no current need.

`pi.nix` gets a new `installPiExtensionDeps` activation block to `npm install` web-fetch's and bash-guard's own dependencies (they carry a `package.json`, unlike pi's `pi install`-managed packages) — same pattern already used for `extensions-available/sandbox`.

Also fixes unrelated leftover unresolved `<<<<<<< Updated upstream` / `=======` / `>>>>>>>` stash-conflict markers that had been committed into the root `.gitignore`.

## Verification

- `nix build .#darwinConfigurations.moria.system --dry-run` evaluates cleanly.
- `npm install` run locally in both vendored extension directories; all three new extensions load with no errors in a live `pi --mode json -p 'Reply with exactly: OK'` smoke test (checked stderr).
- Measured token cost on this host (`~/Git/toolbox` cwd, same method as the existing "token budget" table): 13,232 tokens/request without these three, 14,004 with — **+772 tokens/request** for all three combined.

## Test plan

- [ ] Deploy to moria and citadel (`just dr <host>`)
- [ ] Confirm `~/.pi/agent/extensions/web-fetch` and `bash-guard` have `node_modules` after activation
- [ ] Start a pi session, confirm no extension-load errors
- [ ] Try `bash-guard` against something like `rm -rf /tmp/scratch` and confirm the Run/Abort prompt appears
- [ ] `/skill:youtube-transcript` (or ask Claude Code to use it) against a real video URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TC9LYhkq6NTMo4SiWQHW3i
