### PR TITLE
fix(pi): keep tests/ and extensions-available/ out of stow's reach

### DIFF
--- a/dot/pi/.stow-local-ignore
+++ b/dot/pi/.stow-local-ignore
@@ -1,3 +1,5 @@
 CLAUDE.md
 README.md
 \.gitignore
+tests
+extensions-available


### PR DESCRIPTION
Both directories were added to dot/pi after moria was stowed, so the ignore
list never covered them; the first `just stow pi` on dungeon linked
~/tests and ~/extensions-available into the home directory.
