### PR TITLE
pi: read-only Home Assistant skill

### DIFF
--- a/bin/ha-state.py
+++ b/bin/ha-state.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Home Assistant state, read-only. GET is the only verb, and the token belongs to an HA
+user in the system-read-only group (home-lab/hermes/README.md step 8), so nothing here can
+actuate a device.
+
+    ha-state.py                 every entity: id, state, friendly name (200 lines max)
+    ha-state.py <domain>        one domain, e.g. lock, binary_sensor, climate
+    ha-state.py <entity_id>     one entity with its attributes
+
+Endpoint and token come from HA_URL / HA_BEARER, else ~/.pi/agent/homeassistant.json
+(rendered by `just secrets` in toolbox/nixos). The same script, in bash, serves Hermes:
+home-lab/hermes/scripts/ha-state.sh.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ENTITY_ID = re.compile(r"^[a-z_][a-z0-9_]*\.[a-z0-9_]+$")
+CONFIG = Path.home() / ".pi" / "agent" / "homeassistant.json"
+
+
+def credentials() -> tuple[str, str]:
+    url, token = os.environ.get("HA_URL", ""), os.environ.get("HA_BEARER", "")
+    if not (url and token) and CONFIG.is_file():
+        cfg = json.loads(CONFIG.read_text())
+        url, token = url or cfg.get("url", ""), token or cfg.get("token", "")
+    if not (url and token):
+        sys.exit(f"ha-state: HA_URL/HA_BEARER unset and {CONFIG} missing; run `just secrets` in toolbox/nixos")
+    return url.rstrip("/"), token
+
+
+def get(path: str):
+    url, token = credentials()
+    req = urllib.request.Request(url + path, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as e:
+        sys.exit(f"ha-state: GET {path} -> HTTP {e.code} against {url}")
+    except (urllib.error.URLError, TimeoutError) as e:
+        sys.exit(f"ha-state: GET {path} failed against {url}: {e}")
+
+
+def main(argv: list[str]) -> None:
+    arg = argv[1] if len(argv) > 1 else ""
+    if "." in arg:
+        if not ENTITY_ID.match(arg):
+            sys.exit(f"ha-state: not an entity id: {arg}")
+        e = get(f"/api/states/{arg}")
+        print(e["entity_id"], e["state"], "changed " + e.get("last_changed", ""), sep="\t")
+        attrs = json.dumps(e.get("attributes", {}), ensure_ascii=False)
+        print(attrs[:1500] + (" …" if len(attrs) > 1500 else ""))
+        return
+    rows = sorted(get("/api/states"), key=lambda e: e["entity_id"])
+    if arg:
+        rows = [e for e in rows if e["entity_id"].split(".", 1)[0] == arg]
+    if not rows:
+        print(f"no entities in {arg}" if arg else "no entities")
+        return
+    for e in rows[:200]:
+        print(e["entity_id"], e["state"], e.get("attributes", {}).get("friendly_name", ""), sep="\t")
+    if len(rows) > 200:
+        print(f"… {len(rows) - 200} more; ask for one domain")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/claude-skills/home-assistant/SKILL.md
+++ b/claude-skills/home-assistant/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: home-assistant
+description: Read live Home Assistant state — is a door locked, is anything open, what is the thermostat doing, which battery is low. Use whenever the user asks about the house, a device, or a sensor. Read-only; it cannot control anything.
+---
+
+# Home Assistant (read-only)
+
+One script, on `$PATH` from toolbox `bin/`:
+
+```bash
+ha-state.py                     # every entity: id, state, friendly name (200 lines max)
+ha-state.py lock                # one domain: lock, binary_sensor, climate, sensor, cover, light…
+ha-state.py lock.frontdoor_lock # one entity with its attributes
+```
+
+Go from broad to narrow: a domain first, then the one entity you need. The full list is
+long; never dump it into the conversation. Useful roll-ups already exist as
+`binary_sensor.any_door_unlocked`, `binary_sensor.any_low_battery` and
+`binary_sensor.any_water_leak`.
+
+**Read-only by construction.** The script only ever GETs, and its token belongs to an HA
+user in the `system-read-only` group, so a request to lock, unlock, switch or set anything
+cannot be honoured. Say so; do not look for another way.
+
+## Setup
+
+`~/.pi/agent/homeassistant.json` is rendered by `just secrets` in `toolbox/nixos` from
+`homeassistant.json.tpl` (token `Infra/Hermes/hass_token_pi_harness`, one token per
+consumer so it can be revoked alone). The endpoint is `https://home-assistant.grehg2.xyz`,
+so the machine must be on the tailnet. `HA_URL` / `HA_BEARER` override the file.
+
+## Tool mapping
+
+| Generic move | Claude Code | pi |
+| --- | --- | --- |
+| Run the script | `Bash` | `bash` |

--- a/dot/pi/.gitignore
+++ b/dot/pi/.gitignore
@@ -1,5 +1,7 @@
 # Generated from models.json.tpl via `just secrets` (contains API key)
 .pi/agent/models.json
+# Generated from homeassistant.json.tpl via `just secrets` (read-only HA token)
+.pi/agent/homeassistant.json
 # Managed by home-manager (pi.nix)
 .pi/agent/settings.json
 .pi/agent/reddit-research.json

--- a/dot/pi/.pi/agent/homeassistant.json.tpl
+++ b/dot/pi/.pi/agent/homeassistant.json.tpl
@@ -1,0 +1,4 @@
+{
+  "url": "https://home-assistant.grehg2.xyz",
+  "token": "{{ op://Infra/Hermes/hass_token_pi_harness }}"
+}

--- a/nixos/justfile
+++ b/nixos/justfile
@@ -155,6 +155,7 @@ secrets:
 
   op inject -f -i ../dot/omlx/.omlx/settings.json.tpl -o ../dot/omlx/.omlx/settings.json
   op inject -f -i ../dot/pi/.pi/agent/models.json.tpl -o ../dot/pi/.pi/agent/models.json
+  op inject -f -i ../dot/pi/.pi/agent/homeassistant.json.tpl -o ../dot/pi/.pi/agent/homeassistant.json
   # DeepSeek is a personal, metered API key and citadel is the Mozilla work
   # machine, so it never gets one — the line is stripped before injection rather
   # than merely hidden from pi's model picker, so the key is absent from that


### PR DESCRIPTION
pi reads live Home Assistant state through a GET-only script and a token from the read-only HA user created for Hermes (home-lab #60). Rendered into ~/.pi/agent/homeassistant.json by `just secrets`; SKILL.md in claude-skills/ so both harnesses see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUpmonGLfTEGn1V7d9yBdL