### PR TITLE
feat(dungeon): schedule the Uncanny epub pipeline; clarkesworld moved

### DIFF
--- a/nixos/hosts/macs/dungeon/default.nix
+++ b/nixos/hosts/macs/dungeon/default.nix
@@ -55,6 +55,30 @@
       StandardErrorPath = logFile;
     };
   };
+
+  # Daily check for a newly published issue of a magazine: build its epub, validate it
+  # (epubcheck), import it into the calibre container with a kepub conversion, and
+  # Pushover-notify. Idempotent — state.json in each script's own directory means a day
+  # with nothing new is a fast, silent no-op, so RunAtLoad/KeepAlive don't matter here the
+  # way they do for the open-a agents below. Source lives in home-lab, not here; see
+  # home-lab/scripts/periodicals/README.md for the pipeline and its gotchas.
+  mkPeriodicalAgent = name: hour: {
+    serviceConfig = {
+      ProgramArguments = [
+        "/bin/bash"
+        "/Users/${vars.user.name}/Git/home-lab/scripts/periodicals/${name}/run.sh"
+      ];
+      RunAtLoad = false;
+      StartCalendarInterval = [
+        {
+          Hour = hour;
+          Minute = 0;
+        }
+      ];
+      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/${name}-run.log";
+      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/${name}-run.log";
+    };
+  };
 in {
   imports = [
     ../../../modules/darwin/common.nix
@@ -397,29 +421,11 @@ in {
     };
   };
 
-  # Checks Clarkesworld for a newly published issue and, if there is one, builds its epub,
-  # validates it (epubcheck), imports it into the calibre container with a kepub conversion,
-  # and Pushover-notifies. Idempotent — state.json in the script's own directory means a day
-  # with nothing new is a fast, silent no-op, so RunAtLoad/KeepAlive don't matter here the way
-  # they do for the open-a agents above. Source lives in home-lab, not here — see
-  # home-lab/scripts/clarkesworld/README.md for the full pipeline and gotchas.
-  launchd.user.agents.clarkesworld-run = {
-    serviceConfig = {
-      ProgramArguments = [
-        "/bin/bash"
-        "/Users/${vars.user.name}/Git/home-lab/scripts/clarkesworld/run.sh"
-      ];
-      RunAtLoad = false;
-      StartCalendarInterval = [
-        {
-          Hour = 9;
-          Minute = 0;
-        }
-      ];
-      StandardOutPath = "/Users/${vars.user.name}/Library/Logs/clarkesworld-run.log";
-      StandardErrorPath = "/Users/${vars.user.name}/Library/Logs/clarkesworld-run.log";
-    };
-  };
+  # Staggered by an hour so two scrapes don't share a minute through the same tunnel.
+  # Uncanny is bimonthly and waits for an issue to finish releasing, so it is a no-op on
+  # all but about six mornings a year — see its README.
+  launchd.user.agents.clarkesworld-run = mkPeriodicalAgent "clarkesworld" 9;
+  launchd.user.agents.uncanny-run = mkPeriodicalAgent "uncanny" 10;
 
   # Watch the settings that live OUTSIDE the home-lab repo and revert SILENTLY.
   #


### PR DESCRIPTION
The launchd side of home-lab#65, which adds an Uncanny Magazine epub/kepub pipeline and
moves both magazines under `scripts/periodicals/`.

- **The clarkesworld agent's absolute path moves with it.** A stale path here is a silently
  dead agent — launchd reports nothing when the script it names doesn't exist.
- Both agents are one helper beside `mkNfsMountDaemon` rather than two near-identical
  sixteen-line blocks.
- Staggered an hour apart so two scrapes don't share a minute through the same tunnel.

Uncanny is bimonthly and waits for an issue to finish releasing its free content (half
lands about five weeks after the other half), so `uncanny-run` is a no-op on all but
roughly six mornings a year.

Merge alongside home-lab#65 — this PR alone points the clarkesworld agent at a path that
does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q28irbQa4dm2uM8cDdHGsU
